### PR TITLE
Use functools.lru_cache with maxsize=None

### DIFF
--- a/src/furo/navigation.py
+++ b/src/furo/navigation.py
@@ -16,7 +16,7 @@ def _get_navigation_expand_image(soup):
     return retval
 
 
-@functools.lru_cache
+@functools.lru_cache(maxsize=None)
 def get_navigation_tree(toctree_html):
     """Modify the given navigation tree, with furo-specific elements.
 


### PR DESCRIPTION
`@functools.lru_cache` was added in Python 3.8 which is beyond what Read the Docs currently supports

Didn't test this locally, made this change through GitHub directly. Might want to try building the project in Python 3.7?

Closes #5 