### PR TITLE
Fix stability of resources hashes

### DIFF
--- a/src/furo/theme/base.html
+++ b/src/furo/theme/base.html
@@ -51,7 +51,7 @@
 
     {#- Theme-related stylesheets -#}
     {%- block theme_styles -%}
-    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) | e }}?state={{ furo_asset_hash }}">
+    <link rel="stylesheet" href="{{ furo_asset_hash(pathto('_static/' + style, 1)) | e }}">
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}">
     <link media="(prefers-color-scheme: dark)" rel="stylesheet" href="{{ pathto('_static/pygments_dark.css', 1) }}">
     {% include "partials/_head_css_variables.html" with context %}
@@ -67,7 +67,7 @@
     {%- endblock regular_styles -%}
 
     {%- block extra_styles -%}
-    <link rel="stylesheet" href="{{ pathto('_static/styles/furo-extensions.css', 1) }}?state={{ furo_asset_hash }}">
+    <link rel="stylesheet" href="{{ furo_asset_hash(pathto('_static/styles/furo-extensions.css', 1)) }}">
     {%- endblock -%}
 
     {%- endblock styles -%}
@@ -89,7 +89,7 @@
 
     {# Theme-related JavaScript code #}
     {%- block theme_scripts -%}
-    <script defer src="{{ pathto('_static/scripts/main.js', 1) }}?state={{ furo_asset_hash }}"></script>
+    <script defer src="{{ furo_asset_hash(pathto('_static/scripts/main.js', 1)) }}"></script>
     {%- endblock -%}
 
     {%- endblock scripts -%}


### PR DESCRIPTION
The hash is now only based on the file content.

Fix #38

Note: I tried to implement it as a jinja filter (a.k.a. `path | furo_asset_hash`) but I don't see an obvious way to do it, because Sphinx seems to initialise the template before Jinja so I don't know how to get from the extension to the environment without getting ugly.