### PR TITLE
Fix icon position of sidebar-search-container

### DIFF
--- a/src/furo/assets/styles/components/_sidebar.sass
+++ b/src/furo/assets/styles/components/_sidebar.sass
@@ -30,9 +30,9 @@
 .sidebar-search-container
   display: flex
   align-items: center
-  position: relative
   margin-top: var(--sidebar-search-space-above)
 
+  position: relative
   &::before
     content: ""
     position: absolute

--- a/src/furo/assets/styles/components/_sidebar.sass
+++ b/src/furo/assets/styles/components/_sidebar.sass
@@ -30,6 +30,7 @@
 .sidebar-search-container
   display: flex
   align-items: center
+  position: relative
   margin-top: var(--sidebar-search-space-above)
 
   &::before


### PR DESCRIPTION
If a customized `html_sidebars` list is used and `scroll-start` is set before `search`, then scrolling down the sidebar will also scroll the searchbox's icon, as its position is set to absolute. By setting the position of the searchbox container to relative, the icon stays at its intended position while scrolling.

Example of the sidebar scrolled down by a bit and the icon having a vertical offset:
![image](https://user-images.githubusercontent.com/467294/100491754-7ec09280-3126-11eb-8bc4-3f401c54a944.png)
