### PR TITLE
Fix scrollbar styles affecting document body

### DIFF
--- a/src/furo/assets/styles/_scaffold.sass
+++ b/src/furo/assets/styles/_scaffold.sass
@@ -19,7 +19,7 @@ html
   overflow-x: hidden
   overflow-y: scroll
 
-:not(html)
+:not(html):not(body)
   // Override Firefox scrollbar style
   scrollbar-width: thin
   scrollbar-color: var(--color-foreground-border) transparent


### PR DESCRIPTION
As mentioned in https://github.com/pradyunsg/furo/issues/36#issuecomment-735026670, the document body's scrollbars should not be customized, as having customized/thin scrollbars here is a bad user experience. The custom styles are only meant for the sidebars and the code boxes in the page content.

40acea53f382be77a09e3123d2d54e008c665304