### PR TITLE
Allow setting announcement via templates

### DIFF
--- a/src/furo/theme/page.html
+++ b/src/furo/theme/page.html
@@ -8,15 +8,13 @@
 <label class="overlay sidebar-overlay" for="__navigation"></label>
 <label class="overlay toc-overlay" for="__toc"></label>
 
-{% block announcement %}
 {% if theme_announcement -%}
 <div class="announcement">
   <aside class="announcement-content">
-    {{ theme_announcement }}
+    {% block announcement %} {{ theme_announcement }} {% endblock announcement %}
   </aside>
 </div>
 {%- endif %}
-{% endblock announcement %}
 
 <div class="page">
   <header class="mobile-header">

--- a/src/furo/theme/page.html
+++ b/src/furo/theme/page.html
@@ -8,6 +8,7 @@
 <label class="overlay sidebar-overlay" for="__navigation"></label>
 <label class="overlay toc-overlay" for="__toc"></label>
 
+{% block announcement %}
 {% if theme_announcement -%}
 <div class="announcement">
   <aside class="announcement-content">
@@ -15,6 +16,8 @@
   </aside>
 </div>
 {%- endif %}
+{% endblock announcement %}
+
 <div class="page">
   <header class="mobile-header">
     <div class="header-left">


### PR DESCRIPTION
Hey! 

What do you think about adding a jinja2 block for announcement, to make overriding it easier?

TBH, what I really want is to add a permanent header on the top, which looks similar to announcement; having a block before `<div class="page">` would allow to add it without copy-pasting the whole template.