### PR TITLE
Add language_data.js to search page

### DIFF
--- a/src/furo/theme/search.html
+++ b/src/furo/theme/search.html
@@ -3,6 +3,7 @@
 {%- block regular_scripts -%}
 {{ super() }}
 <script defer src="{{ pathto('_static/searchtools.js', 1) }}"></script>
+<script defer src="{{ pathto('_static/language_data.js', 1) }}"></script>
 {%- endblock regular_scripts-%}
 
 {%- block htmltitle -%}


### PR DESCRIPTION
Search with furo theme is currently broken - see e.g. https://pradyunsg.me/furo/search/?q=css&check_keywords=yes&area=default

I think this is caused by a missing JS file (https://github.com/sphinx-doc/sphinx/blob/a18fee24f2b7f3507cfb02d56a48b107a78330e0/sphinx/themes/basic/search.html#L15), which is added in this PR.


