### PR TITLE
Fix "Stemmer not defined" error in search page

### DIFF
--- a/src/furo/theme/search.html
+++ b/src/furo/theme/search.html
@@ -3,6 +3,7 @@
 {%- block regular_scripts -%}
 {{ super() }}
 <script defer src="{{ pathto('_static/searchtools.js', 1) }}"></script>
+<script defer src="{{ pathto('_static/language_data.js', 1) }}"></script>
 {%- endblock regular_scripts-%}
 
 {%- block htmltitle -%}


### PR DESCRIPTION
When I'm using the search function with Sphinx 3.4.0 and Furo 2020.12.9b21, the following error occurs:

```
Uncaught ReferenceError: Stemmer is not defined
    at Object.query (searchtools.js:158)
    at Object.performSearch (searchtools.js:146)
    at Object.init (searchtools.js:79)
    at HTMLDocument.<anonymous> (searchtools.js:513)
    at e (jquery.js:2)
    at t (jquery.js:2)
```

This PR would fix it.