### PR TITLE
Add defer to js_tag on Python side

### DIFF
--- a/src/furo/__init__.py
+++ b/src/furo/__init__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from bs4 import BeautifulSoup
 from pygments.token import Text
+from sphinx.builders.html import JavaScript
 
 from .navigation import get_navigation_tree
 
@@ -123,6 +124,16 @@ def furo_asset_hash(path):
 def _html_page_context(app, pagename, templatename, context, doctree):
     if app.config.html_theme != "furo":
         return
+
+    # Add attributes to the scripts loaded with `js_tag`
+    sphinx_js_tag = context["js_tag"]
+
+    def furo_js_tag(js):
+        if isinstance(js, JavaScript):
+            js.attributes["defer"] = "defer"
+        return sphinx_js_tag(js)
+
+    context["js_tag"] = furo_js_tag
 
     # Basic constants
     context["furo_version"] = __version__

--- a/src/furo/theme/base.html
+++ b/src/furo/theme/base.html
@@ -79,11 +79,7 @@
     {# This is *exactly* how `basic` handles this file. #}
     <script id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
     {% for path in script_files -%}
-      {% set tag = js_tag(path) -%}
-      {%- if tag.startswith("<script ") -%}
-        {%- set tag = tag[:7] + " defer" + tag[7:] -%}
-      {%- endif -%}
-      {{ tag }}
+      {{ js_tag(path) }}
     {% endfor -%}
     {%- endblock regular_scripts -%}
 


### PR DESCRIPTION
Sphinx has the capability to include attributes for JavaScript files.
This commit changes the existing template string manipulation to
use the built-in support for JavaScript attributes instead.