### PR TITLE
Simplify JS and CSS inclusion

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -52,6 +52,7 @@ def docs_live(session):
             r"--re-ignore=src/.*/theme/static/.*\.(css|js)",  # ignore the generated files
             "--open-browser",
             # for sphinx
+            "-v",
             "-b=dirhtml",
             "-a",
             docs_dir,

--- a/src/furo/__init__.py
+++ b/src/furo/__init__.py
@@ -157,6 +157,8 @@ def _html_page_context(app, pagename, templatename, context, doctree):
         context["body"] = wrap_elements_that_can_get_too_wide(context["body"])
 
     context["style"] = furo_asset_hash(context["style"])
+    context["furo_extensions_style"] = furo_asset_hash("styles/furo-extensions.css")
+    context["furo_main_script"] = furo_asset_hash("scripts/main.js")
 
 
 def setup(app):
@@ -164,9 +166,6 @@ def setup(app):
     app.require_sphinx("3.0")
 
     app.add_html_theme("furo", str(_FURO_THEME_PATH))
-
-    app.add_css_file(furo_asset_hash("styles/furo-extensions.css"))
-    app.add_js_file(furo_asset_hash("scripts/main.js"))
 
     app.connect("html-page-context", _html_page_context)
 

--- a/src/furo/theme/base.html
+++ b/src/furo/theme/base.html
@@ -1,4 +1,3 @@
-{% from "basic/layout.html" import css, script with context %}
 <!doctype html>
 <html class="no-js">
   <head>
@@ -52,15 +51,20 @@
 
     {#- Theme-related stylesheets -#}
     {%- block theme_styles -%}
+    <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css">
+    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) | e }}" type="text/css">
     {% include "partials/_head_css_variables.html" with context %}
     {%- endblock -%}
 
     {# Custom stylesheets #}
     {%- block regular_styles -%}
-    {{- css() }}
+    {%- for path in css_files -%}
+      {{ css_tag(path) }}
+    {% endfor -%}
     {%- endblock regular_styles -%}
 
     {%- block extra_styles -%}
+    <link rel="stylesheet" href="{{ pathto('_static/' + furo_extensions_style, 1) | e }}" type="text/css">
     {%- endblock -%}
 
     {%- endblock styles -%}
@@ -69,11 +73,16 @@
 
     {# Custom JS #}
     {%- block regular_scripts -%}
-    {{- script() }}
+    {# This is *exactly* how `basic` handles this file. #}
+    <script id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
+    {% for path in script_files -%}
+      {{ js_tag(path) }}
+    {% endfor -%}
     {%- endblock regular_scripts -%}
 
     {# Theme-related JavaScript code #}
     {%- block theme_scripts -%}
+    <script defer src="{{ pathto('_static/' + furo_main_script, 1) | e }}"></script>
     {%- endblock -%}
 
     {%- endblock scripts -%}

--- a/src/furo/theme/base.html
+++ b/src/furo/theme/base.html
@@ -1,3 +1,4 @@
+{% from "basic/layout.html" import css, script with context %}
 <!doctype html>
 <html class="no-js">
   <head>
@@ -51,23 +52,15 @@
 
     {#- Theme-related stylesheets -#}
     {%- block theme_styles -%}
-    <link rel="stylesheet" href="{{ furo_asset_hash(pathto('_static/' + style, 1)) | e }}">
-    <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}">
-    <link media="(prefers-color-scheme: dark)" rel="stylesheet" href="{{ pathto('_static/pygments_dark.css', 1) }}">
     {% include "partials/_head_css_variables.html" with context %}
     {%- endblock -%}
 
     {# Custom stylesheets #}
     {%- block regular_styles -%}
-    {%- for path in css_files -%}
-    {% if not path.filename.startswith("pygments_dark") -%}
-      {{ css_tag(path) }}
-    {%- endif %}
-    {% endfor -%}
+    {{- css() }}
     {%- endblock regular_styles -%}
 
     {%- block extra_styles -%}
-    <link rel="stylesheet" href="{{ furo_asset_hash(pathto('_static/styles/furo-extensions.css', 1)) }}">
     {%- endblock -%}
 
     {%- endblock styles -%}
@@ -76,16 +69,11 @@
 
     {# Custom JS #}
     {%- block regular_scripts -%}
-    {# This is *exactly* how `basic` handles this file. #}
-    <script id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
-    {% for path in script_files -%}
-      {{ js_tag(path) }}
-    {% endfor -%}
+    {{- script() }}
     {%- endblock regular_scripts -%}
 
     {# Theme-related JavaScript code #}
     {%- block theme_scripts -%}
-    <script defer src="{{ furo_asset_hash(pathto('_static/scripts/main.js', 1)) }}"></script>
     {%- endblock -%}
 
     {%- endblock scripts -%}


### PR DESCRIPTION
This PR utilises the builtin `add_js_file`/`add_css_file` methods to register additional JS/CSS for the theme. As a result, the hashing is moved out of the templates.

To further simplify the templates, the `css` and `script` macros from `basic/layout.html` are used to generate the JS and CSS content.

For debugging, the `docs-live` environment now builds with greater verbosity from Sphinx.