### PR TITLE
Replace domainindex.html with (more-or-less) the sphinx-doc/sphinx version

### DIFF
--- a/src/furo/theme/furo/domainindex.html
+++ b/src/furo/theme/furo/domainindex.html
@@ -1,10 +1,56 @@
-{% extends "page.html" %}
+{#
+basic/domainindex.html
+~~~~~~~~~~~~~~~~~~~~~~
 
+Template for domain indices (module index, ...).
+
+:copyright: Copyright 2007-2021 by the Sphinx team, see AUTHORS.
+:license: BSD, see LICENSE for details.
+#}
+{%- extends "page.html" %}
+{% set title = indextitle %}
+{% block extrahead %}
+{{ super() }}
+{% if not embedded and collapse_index %}
+<script>
+      DOCUMENTATION_OPTIONS.COLLAPSE_INDEX = true;
+    </script>
+{% endif %}
+{% endblock %}
 {% block content %}
-Hiya!
 
-This page is not currently supported by the Sphinx theme being used by
-this documentation. If you're seeing this, please drop a comment on
-<a href="https://github.com/pradyunsg/furo/issues/50">this issue</a>
-with a link to this page. :)
-{% endblock content %}
+{%- set groupid = idgen() %}
+
+<h1>{{ indextitle }}</h1>
+
+<div class="modindex-jumpbox">
+    {%- for (letter, entries) in content %}
+    <a href="#cap-{{ letter }}"><strong>{{ letter }}</strong></a>
+    {%- if not loop.last %} | {% endif %}
+    {%- endfor %}
+</div>
+
+<table class="indextable modindextable">
+    {%- for letter, entries in content %}
+    <tr class="pcap"><td></td><td>&#160;</td><td></td></tr>
+    <tr class="cap" id="cap-{{ letter }}"><td></td><td>
+        <strong>{{ letter }}</strong></td><td></td></tr>
+    {%- for (name, grouptype, page, anchor, extra, qualifier, description)
+    in entries %}
+    <tr{% if grouptype == 2 %} class="cg-{{ groupid.current() }}"{% endif %}>
+    <td>{% if grouptype == 1 -%}
+        <img src="{{ pathto('_static/minus.png', 1) }}" class="toggler"
+             id="toggle-{{ groupid.next() }}" style="display: none" alt="-" />
+        {%- endif %}</td>
+    <td>{% if grouptype == 2 %}&#160;&#160;&#160;{% endif %}
+        {% if page %}<a href="{{ pathto(page)|e }}#{{ anchor }}">{% endif -%}
+            <code class="xref">{{ name|e }}</code>
+            {%- if page %}</a>{% endif %}
+        {%- if extra %} <em>({{ extra|e }})</em>{% endif -%}
+    </td><td>{% if qualifier %}<strong>{{ qualifier|e }}:</strong>{% endif %}
+    <em>{{ description|e }}</em></td></tr>
+    {%- endfor %}
+    {%- endfor %}
+</table>
+
+{% endblock %}


### PR DESCRIPTION
This is copied from https://github.com/sphinx-doc/sphinx/blob/3.x/sphinx/themes/basic/domainindex.html and then edited to extend base.html rather than layout.html.

I thought I'd already tried something similar to this, but obviously not!

This seems to work, but maybe further work is needed in order fully to integrate it into the theme.