### PR TITLE
Add git edit buttons in the footer

### DIFF
--- a/src/furo/theme/furo/gitedit.html
+++ b/src/furo/theme/furo/gitedit.html
@@ -1,0 +1,57 @@
+{#- Support for Sphinx 1.3+ page_source_suffix, but don't break old builds. #}
+
+{%- if page_source_suffix %}
+   {%- set suffix = page_source_suffix %}
+{%- else %}
+   {%- set suffix = source_suffix %}
+{%- endif %}
+
+{%- if meta is defined and meta is not none %}
+   {%- set check_meta = True %}
+{%- else %}
+   {%- set check_meta = False %}
+{%- endif %}
+
+{%- if check_meta and 'github_url' in meta %}
+   {%- set display_github = True %}
+{%- endif %}
+
+{%- if check_meta and 'bitbucket_url' in meta %}
+   {%- set display_bitbucket = True %}
+{%- endif %}
+
+{%- if check_meta and 'gitlab_url' in meta %}
+   {%- set display_gitlab = True %}
+{%- endif %}
+
+{%- set display_vcs_links = display_vcs_links if display_vcs_links is defined else True %}
+
+{%- if hasdoc(pagename) and display_vcs_links %}
+  |
+  {%- if display_github %}
+    {%- if check_meta and 'github_url' in meta %}
+      <!-- User defined GitHub URL -->
+      <a href="{{ meta['github_url'] }}" class="muted-link"> {{ _('Edit on GitHub') }}</a>
+    {%- else %}
+      <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode or "blob" }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="muted-link"> {{ _('Edit on GitHub') }}</a>
+    {%- endif %}
+  {%- elif display_bitbucket %}
+    {%- if check_meta and 'bitbucket_url' in meta %}
+      <!-- User defined Bitbucket URL -->
+      <a href="{{ meta['bitbucket_url'] }}" class="muted-link"> {{ _('Edit on Bitbucket') }}</a>
+    {%- else %}
+      <a href="https://bitbucket.org/{{ bitbucket_user }}/{{ bitbucket_repo }}/src/{{ bitbucket_version}}{{ conf_py_path }}{{ pagename }}{{ suffix }}?mode={{ theme_vcs_pageview_mode or "view" }}" class="muted-link"> {{ _('Edit on Bitbucket') }}</a>
+    {%- endif %}
+  {%- elif display_gitlab %}
+    {%- if check_meta and 'gitlab_url' in meta %}
+      <!-- User defined GitLab URL -->
+      <a href="{{ meta['gitlab_url'] }}" class="muted-link"> {{ _('Edit on GitLab') }}</a>
+    {%- else %}
+      <a href="https://{{ gitlab_host|default("gitlab.com") }}/{{ gitlab_user }}/{{ gitlab_repo }}/{{ theme_vcs_pageview_mode or "blob" }}/{{ gitlab_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="muted-link"> {{ _('Edit on GitLab') }}</a>
+    {%- endif %}
+  {%- elif show_source and source_url_prefix %}
+    <a href="{{ source_url_prefix }}{{ pagename }}{{ suffix }}" class="muted-link">{{ _('Show source') }}</a>
+  {%- elif show_source and has_source and sourcename %}
+    <a href="{{ pathto('_sources/' + sourcename, true)|e }}" class="muted-link" rel="nofollow"> {{ _('Show source') }}</a>
+  {%- endif %}
+{%- endif %}

--- a/src/furo/theme/furo/page.html
+++ b/src/furo/theme/furo/page.html
@@ -109,13 +109,7 @@
               <a href="https://github.com/pradyunsg/furo">Furo theme</a>.
             {%- endtrans %}
           {%- endif %}
-          {%- if show_source and has_source and sourcename %}
-            |
-            <a class="muted-link" href="{{ pathto('_sources/' + sourcename, true)|e }}"
-               rel="nofollow">
-              {{ _('Show Source') }}
-            </a>
-          {%- endif %}
+          {% include "gitedit.html" %}
         </div>
         {% endblock footer %}
       </footer>


### PR DESCRIPTION
- Create a new component for Git edit links
- Most of the code is taken from the sphinx_rtd_theme
- Support for Github, Gitlab and Bitbucket
- When none is available the show source button will be shown