### PR TITLE
Update sphinx requirement to `>=3`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description-file = "README.md"
 requires-python = ">=3.6"
 requires = [
   "beautifulsoup4",
-  "sphinx ~= 3.0",
+  "sphinx >= 3.0",
 ]
 classifiers = [
   "Framework :: Sphinx",


### PR DESCRIPTION
This allows use of furo with sphinx v4 and any future v5+ without pip complaining or causing any difficulty. It's possible that `furo` would be broken by a future sphinx version, but accepting that risk may be a better and more pragmatic solution than preventing users from trying out the combination.

resolves https://github.com/pradyunsg/furo/discussions/148 (do we "resolve" discussions?)

---

I opened this to try to get the ball rolling on sphinx v4 compatibility.

I want to use `furo` in [webargs](https://github.com/marshmallow-code/webargs/issues/610#issuecomment-853432935) and maybe make the case for using it for the `marshmallow` docs too, if we like the result. But the reason we're looking at switching our theme is that our old one is unmaintained, and not sphinx v4 compatible.

Looking at the [sphinx 4.0 changelog](https://www.sphinx-doc.org/en/master/changes.html#release-4-0-0-released-may-09-2021), nothing appears, at a glance, to be incompatible with furo ~, but it's hard to be certain without thorough testing~.

~I wasn't able to get `npm install` working right now, so I can't check `nox -s docs`. If there's something more I can do in terms of leg-work to validate that sphinx v4 + furo works okay, please let me know.~

I've built locally and the docs seem to render just fine, with no new warnings or errors. I see this warning, but I believe it's expected:
```
.../furo/docs/kitchen-sink/demo.rst:279: WARNING: citation not found: nonexistent
```