### PR TITLE
Target [source] links more accurately in SASS

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,13 @@
 # Full list of options can be found in the Sphinx documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import os
+import sys
+
+# add the demo python code to the path, so that it can be used to demonstrate
+# source links
+sys.path.append(os.path.abspath("./kitchen-sink/demo_py"))
+
 #
 # -- Project information -----------------------------------------------------
 #

--- a/docs/kitchen-sink/autodoc.rst
+++ b/docs/kitchen-sink/autodoc.rst
@@ -1,0 +1,9 @@
+*******
+Autodoc
+*******
+
+This is a run of automodule to grab classes, functions, and members from the
+demo module.
+
+.. automodule:: furo_demo_module
+    :members:

--- a/docs/kitchen-sink/demo_py/furo_demo_module.py
+++ b/docs/kitchen-sink/demo_py/furo_demo_module.py
@@ -1,0 +1,28 @@
+"""
+This is a demo module included in the docs in order to exercise viewcode,
+autodoc, and other related functionality.
+"""
+
+
+class Foo:
+    """
+    A demo class of type Foo.
+
+    Has a method baz() returning ints.
+    """
+
+    def baz(self) -> int:
+        """
+        Return a random integer.
+        See also: https://xkcd.com/221/
+        """
+        return 3
+
+
+def bar(f: Foo) -> Foo:
+    """
+    the identity function, but only for Foos
+    """
+    if isinstance(f, Foo):
+        return f
+    raise TypeError("Expected a Foo!")

--- a/docs/kitchen-sink/index.md
+++ b/docs/kitchen-sink/index.md
@@ -12,4 +12,5 @@ demo
 lists_tables
 really-long
 structure
+autodoc
 ```

--- a/src/furo/assets/styles/content/_api.sass
+++ b/src/furo/assets/styles/content/_api.sass
@@ -56,9 +56,7 @@ dl.exception
       padding-right: 0.25rem
 
     // adjust the size of the [source] link on the right.
-    code.sig-name.descname,  // final part of named object.
-    span.sig-paren,          // final ')' on a method definition
-    > span.pre               // return annotation, on a function definition
+    a.reference.internal
       .viewcode-link
         width: 3.5rem
         font-size: var(--font-size--small)

--- a/src/furo/assets/styles/content/_api.sass
+++ b/src/furo/assets/styles/content/_api.sass
@@ -55,13 +55,12 @@ dl.exception
       color: var(--color-api-keyword)
       padding-right: 0.25rem
 
-    // Align the [source] to the right.
+    // adjust the size of the [source] link on the right.
     code.sig-name.descname,  // final part of named object.
     span.sig-paren,          // final ')' on a method definition
     > span.pre               // return annotation, on a function definition
-      + a.reference.internal
+      .viewcode-link
         width: 3.5rem
-        float: right
         font-size: var(--font-size--small)
 
 .sig-name
@@ -81,7 +80,7 @@ div.versionadded, div.versionchanged, div.deprecated
     margin-top: 0.125rem
     margin-bottom: 0.125rem
 
-// Align the [docs] to the right.
+// Align the [docs] and [source] to the right.
 .viewcode-link, .viewcode-back
   float: right
   text-align: right


### PR DESCRIPTION
This is a patch for #137

It works on the site where I tested it, and doesn't appear to break the kitchen-sink demo.

---

Because `.viewcode-link` is already marked with `float: right` independently, don't assign that style redundantly when styling `[source]` links attached to function and class defintions.

Use `.viewcode-link` instead of `a.reference.internal` to ensure that the styling for `[source]` links is not accidentally applied to return type annotations which are also internal references.