### PR TITLE
support various footer configurations

### DIFF
--- a/src/furo/theme/furo/page.html
+++ b/src/furo/theme/furo/page.html
@@ -115,7 +115,7 @@
               {%- endtrans %}
             {%- else %}
               {% trans copyright=copyright|e -%}
-                Copyright &#169; {{ copyright }}.
+                Copyright &#169; {{ copyright }}
               {%- endtrans %}
             {%- endif %}
           {%- endif %}

--- a/src/furo/theme/furo/page.html
+++ b/src/furo/theme/furo/page.html
@@ -115,18 +115,18 @@
               {%- endtrans %}
             {%- else %}
               {% trans copyright=copyright|e -%}
-                Copyright &#169; {{ copyright }}
+                Copyright &#169; {{ copyright }}.
               {%- endtrans %}
             {%- endif %}
           {%- endif %}
           {%- if last_updated %}
-            |
+            {%- if show_copyright %} | {%- endif %}
             {% trans last_updated=last_updated|e -%}
               Last updated on {{ last_updated }}.
             {%- endtrans %}
           {%- endif %}
           {%- if show_sphinx %}
-            |
+            {%- if show_copyright or last_updated %} | {%- endif %}
             {% trans -%}
               Built with <a href="https://www.sphinx-doc.org/">Sphinx</a>
               and
@@ -135,7 +135,7 @@
             {%- endtrans %}
           {%- endif %}
           {%- if show_source and has_source and sourcename %}
-            |
+            {%- if show_copyright or last_updated or show_sphinx %} | {%- endif %}
             <a class="muted-link" href="{{ pathto('_sources/' + sourcename, true)|e }}"
                rel="nofollow">
               {{ _('Show Source') }}


### PR DESCRIPTION
Adjust the injection of separators between various components of a footer to only do so when needed. This is to handle various configuration states a user may set for `html_last_updated_fmt`, `html_show_copyright`, `html_show_sourcelink` or `html_show_sphinx`.

---

A capture of various configuration modes:

![image](https://user-images.githubusercontent.com/1834509/131241404-42950df0-ee75-494a-b580-a8c3aed9a071.png)

---

Note that with the provides changes, there are two minor tweaks to be considered before accepting this change.

**1)**
The period is purposely not injected at the end of a copyright statement. This provides flexibility for documentations which may not desire to inject a period after its statement (assuming there is no trailing content to append in the footer). For example:

![image](https://user-images.githubusercontent.com/1834509/131241551-9c1f55ad-374a-4c1d-833a-63fca7009bef.png)

**2)**
The vertical spacer was omitted in these changes to opt for using the existing period entries as the separator (not including the "Show Source" entry. Below shows the existing pip documentation -- and when comping to the above figure, the difference can be observed:

![image](https://user-images.githubusercontent.com/1834509/131241445-6a7cbae6-ae1e-4e7e-9dd4-a42031296d17.png)

If this is not desired, the merge request can be modified.

---

See also: https://github.com/pradyunsg/furo/discussions/220