### PR TITLE
fallback to project name branding/title for singlehtml

### DIFF
--- a/src/furo/theme/furo/base.html
+++ b/src/furo/theme/furo/base.html
@@ -41,7 +41,9 @@
 
     {#- Site title -#}
     {%- block htmltitle -%}
-      {% if pagename == master_doc %}
+      {% if not docstitle %}
+        <title>{{ title|striptags|e }}</title>
+      {% elif pagename == master_doc %}
         <title>{{ docstitle|striptags|e }}</title>
       {% else %}
         <title>{{ title|striptags|e }} - {{ docstitle|striptags|e }}</title>

--- a/src/furo/theme/furo/page.html
+++ b/src/furo/theme/furo/page.html
@@ -29,7 +29,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="{{ pathto(master_doc) }}"><div class="brand">{{ docstitle }}</div></a>
+      <a href="{{ pathto(master_doc) }}"><div class="brand">{{ docstitle if docstitle else project }}</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">

--- a/src/furo/theme/furo/sidebar/brand.html
+++ b/src/furo/theme/furo/sidebar/brand.html
@@ -25,7 +25,7 @@ Hope your day's going well. :)
   </div>
   {%- endif %}
   {% if not theme_sidebar_hide_name %}
-  <span class="sidebar-brand-text">{{ docstitle }}</span>
+  <span class="sidebar-brand-text">{{ docstitle if docstitle else project }}</span>
   {%- endif %}
   {% endblock brand_content %}
 </a>


### PR DESCRIPTION
The title element and sidebar branding name both use the `docstitle` configuration \[1\]\[2\] for its content; however, when using a `singlehtml` builder, this option is not available \[1\]\[3\]. In the case where this option is not available, this will lead to the sidebar name rendering a value "None" (unless `sidebar_hide_name` is explicitly configured to `True`) and some title values as "None". This commit adjusts the case where `docstitle` is not configured, by falling back onto the configured `project` value (for the sidebar) or the `title` value (for the title element).

\[1\]: https://www.sphinx-doc.org/en/master/templating.html?highlight=docstitle#docstitle
\[2\]: https://github.com/sphinx-doc/sphinx/blob/514fca7a407f03fae4c788178555a74256936655/sphinx/builders/html/__init__.py#L509
\[3\]: https://github.com/sphinx-doc/sphinx/blob/514fca7a407f03fae4c788178555a74256936655/sphinx/builders/singlehtml.py#L139

---

Examples of "None" renders before this pull request:

_(sidebar when using singlehtml)_
![image](https://user-images.githubusercontent.com/1834509/132277534-32a9340b-ec3c-4532-8787-32ef0f6047d3.png)

(title section using singlehtml; mobile emulated)
![image](https://user-images.githubusercontent.com/1834509/132277539-6c855065-aea3-4cd7-a308-948588f4e9a8.png)
