### PR TITLE
Use noscript for search js notification

### DIFF
--- a/src/furo/theme/furo/search.html
+++ b/src/furo/theme/furo/search.html
@@ -11,13 +11,14 @@
 {%- endblock htmltitle -%}
 
 {% block content %}
-<div id="fallback" class="admonition error">
+<noscript>
+<div class="admonition error">
   <p class="admonition-title">{% trans %}Error{% endtrans %}</p>
   <p>
     {% trans %}Please activate JavaScript to enable the search functionality.{% endtrans %}
   </p>
 </div>
-<script>document.getElementById('fallback').hidden = true;</script>
+</noscript>
 
 <div id="search-results"></div>
 {% endblock %}


### PR DESCRIPTION
The "search.html" template will generate a warning admonition about requiring JavaScript for search and automatically hiding the element when supported. While functional, if a client renders the page slowly, the warning notification may be visible to the user for a moment.

Instead of relying on JavaScript to suppress this warning, use a `noscript` tag to hide the warning for clients who do not support JavaScript. This also has the benefit of one less JavaScript call required by a client.

---

See also: https://github.com/sphinx-doc/sphinx/pull/9617