### PR TITLE
Fix URL in html_logo and html_favicon

### DIFF
--- a/src/furo/theme/furo/base.html
+++ b/src/furo/theme/furo/base.html
@@ -30,8 +30,8 @@
     {%- endblock linktags %}
 
     {# Favicon #}
-    {%- if favicon -%}
-      <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>
+    {%- if favicon_url -%}
+      <link rel="shortcut icon" href="{{ favicon_url }}"/>
     {%- endif -%}
 
     {#- Generator banner -#}

--- a/src/furo/theme/furo/sidebar/brand.html
+++ b/src/furo/theme/furo/sidebar/brand.html
@@ -13,9 +13,9 @@ Hope your day's going well. :)
 -#}
 <a class="sidebar-brand{% if logo %} centered{% endif %}" href="{{ pathto(master_doc) }}">
   {% block brand_content %}
-  {%- if logo %}
+  {%- if logo_url %}
   <div class="sidebar-logo-container">
-    <img class="sidebar-logo" src="{{ pathto('_static/' + logo, 1) }}" alt="Logo"/>
+    <img class="sidebar-logo" src="{{ logo_url }}" alt="Logo"/>
   </div>
   {%- endif %}
   {%- if theme_light_logo and theme_dark_logo %}


### PR DESCRIPTION
Since Sphinx 4, it's possible to use URL in html_logo and html_favicon
options. It is not currently processed correctly and we end up with
something like "_static/https://example.com/logo.png" as image path.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>