### PR TITLE
Build on Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.10"
+    nodejs: "14"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,7 +90,7 @@ html_theme_options = {
 }
 
 # Generate JS/CSS assets before running Sphinx on Read the Docs
-if os.environ.get('READTHEDOCS') == 'True':
+if os.environ.get("READTHEDOCS") == "True":
     subprocess.run(
         [
             "npx",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,11 +89,12 @@ html_theme_options = {
     )
 }
 
-# Generate JS/CSS assets before running Sphinx
-subprocess.run(
-    [
-        "npx",
-        "gulp",
-        "build",
-    ]
-)
+# Generate JS/CSS assets before running Sphinx on Read the Docs
+if os.environ.get('READTHEDOCS') == 'True':
+    subprocess.run(
+        [
+            "npx",
+            "gulp",
+            "build",
+        ]
+    )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,8 +90,10 @@ html_theme_options = {
 }
 
 # Generate JS/CSS assets before running Sphinx
-subprocess.run([
-    'npx',
-    'gulp',
-    'build',
-])
+subprocess.run(
+    [
+        "npx",
+        "gulp",
+        "build",
+    ]
+)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 import os
+import subprocess
 import sys
 
 # add the demo python code to the path, so that it can be used to demonstrate
@@ -87,3 +88,10 @@ html_theme_options = {
         "</a>!"
     )
 }
+
+# Generate JS/CSS assets before running Sphinx
+subprocess.run([
+    'npx',
+    'gulp',
+    'build',
+])


### PR DESCRIPTION
Hi @pradyunsg! I was experimenting with a new beta feature that we deployed yesterday in Read the Docs to allow setting a version for extra tools, for example, NodeJS (https://github.com/readthedocs/readthedocs-docker-images/issues/107)

This PR makes usage of that beta feature (`build.os` and `build.tools` configs from the `.readthedocs.yaml` file) to use Ubuntu 20.04 LTS and install NodeJS v14. Then, it runs `npx gulp build` from inside `conf.py` before building documentation with Sphinx.

I hope you find this useful! Let me know 😄 