### PR TITLE
Change color for names in API documentation, to differentiate them from links

### DIFF
--- a/src/furo/assets/styles/variables/_colors.scss
+++ b/src/furo/assets/styles/variables/_colors.scss
@@ -33,9 +33,9 @@
   --color-api-background: var(--color-background-secondary);
   --color-api-background-hover: var(--color-background-hover);
   --color-api-overall: var(--color-foreground-secondary);
-  --color-api-name: var(--color-brand-content);
-  --color-api-pre-name: var(--color-brand-content);
-  --color-api-paren: var(--color-foreground-primary);
+  --color-api-name: var(--color-foreground-primary);
+  --color-api-pre-name: var(--color-foreground-primary);
+  --color-api-paren: var(--color-foreground-secondary);
   --color-api-keyword: var(--color-problematic);
   --color-api-highlight-on-target: #ffffcc;
 


### PR DESCRIPTION
_Copied from https://github.com/pradyunsg/furo/discussions/302_

As seen on https://pradyunsg.me/furo/kitchen-sink/autodoc/. FWIW, I think of myself as a savvy web user, without disabilities, and I find the blue API names confusing. I feel an urge to click on them, and find them distracting from the clickable elements. I also didn't notice the underline on the links until I was told it was there.

Here's one reference re: link colors: https://www.nngroup.com/articles/guidelines-for-visualizing-links/. The relevant bit:

> Never show text in your chosen link colors unless it's a link.
> 
> You should generally avoid color for text unless it's a link. However, assuming it differs from the link color, you can sometimes use colored text without causing major usability problems. For example, in a checklist summary, you could show the word "okay" in green and the word "error" in red. (The fact that the word meanings are clearly different provides the required redundant cue for color-blind users.)
> 
> Don't use blue for non-link text, even if you don't use blue as your link color. Blue is still the color with the strongest perceived affordance of clickability.

I think using the primary foreground color is sufficiently readable, thanks to the background and bolding.

![127 0 0 1_52890_kitchen-sink_autodoc html (1)](https://user-images.githubusercontent.com/1326704/141679112-d1c151a7-1bc1-410f-b48e-9ea2293a9481.png)
