### PR TITLE
Force highlight (pre) line height style

### DIFF
--- a/src/furo/assets/styles/content/_code.sass
+++ b/src/furo/assets/styles/content/_code.sass
@@ -29,7 +29,7 @@ pre
 
   // Needed to have more specificity than pygments' "pre" selector. :(
   article .highlight &
-    line-height: 1.5
+    line-height: 1.5 !important
 
   &.literal-block,
   .highlight &


### PR DESCRIPTION
When toggling between light and dark mode, Pygments will configure a line-height value that is inconsistent with the existing light mode. This theme's code style configures a `line-height` of `1.5`, but when Pygments styling is changed, the line-height is adjusted to `125%`:

    @media (prefers-color-scheme: dark)
    body:not([data-theme="light"]) .highlight pre {
        line-height: 125%;
    }

To prevent this, providing an important hint on the line-height entry to ensure a consistent height between the two modes.

---

Noticing this on Chrome (v96), when comparing modes between light/dark on the example images document:

![image](https://user-images.githubusercontent.com/1834509/143281098-7f6c0768-bf93-4375-ae29-a5f177134be9.png)

The following shows the style override:

![image](https://user-images.githubusercontent.com/1834509/143281147-0ba09285-1286-4411-ae5d-57fc77be6250.png)

I assume this would be a valid case to apply the `!important` hint; however, please correct me if I am wrong.