### PR TITLE
Improve support for print media

### DIFF
--- a/src/furo/__init__.py
+++ b/src/furo/__init__.py
@@ -336,12 +336,16 @@ def get_pygments_stylesheet() -> str:
 
     lines.extend(_get_styles(light_formatter, prefix=".highlight"))
 
+    lines.append("@media not print {")
+
     dark_prefix = 'body[data-theme="dark"] .highlight'
     lines.extend(_get_styles(dark_formatter, prefix=dark_prefix))
 
     not_light_prefix = 'body:not([data-theme="light"]) .highlight'
     lines.append("@media (prefers-color-scheme: dark) {")
     lines.extend(_get_styles(dark_formatter, prefix=not_light_prefix))
+    lines.append("}")
+
     lines.append("}")
 
     return "\n".join(lines)

--- a/src/furo/assets/styles/base/_index.sass
+++ b/src/furo/assets/styles/base/_index.sass
@@ -1,3 +1,4 @@
+@import "print"
 @import "screen-readers"
 @import "theme"
 @import "typography"

--- a/src/furo/assets/styles/base/_print.sass
+++ b/src/furo/assets/styles/base/_print.sass
@@ -1,0 +1,29 @@
+// This file contains styles for managing print media.
+
+////////////////////////////////////////////////////////////////////////////////
+// Hide elements not relevant to print media.
+////////////////////////////////////////////////////////////////////////////////
+@media print
+  // Hide icon container.
+  .content-icon-container
+    display: none !important
+
+  // Hide showing header links if hovering over when printing.
+  .headerlink
+    display: none !important
+
+  // Hide mobile header.
+  .mobile-header
+    display: none !important
+
+  // Hide navigation links.
+  .related-pages
+    display: none !important
+
+////////////////////////////////////////////////////////////////////////////////
+// Tweaks related to decolorization.
+////////////////////////////////////////////////////////////////////////////////
+@media print
+  // Apply a border around code which no longer have a color background.
+  .highlight
+    border: 0.1pt solid var(--color-foreground-border)

--- a/src/furo/assets/styles/base/_theme.sass
+++ b/src/furo/assets/styles/base/_theme.sass
@@ -18,24 +18,26 @@ body
 html body .only-dark
   display: none !important
 
-// Enable dark-mode, if requested.
-body[data-theme="dark"]
-  @include colors-dark
-
-  html & .only-light
-    display: none !important
-  .only-dark
-    display: block !important
-
-// Enable dark mode, unless explicitly told to avoid.
-@media (prefers-color-scheme: dark)
-  body:not([data-theme="light"])
+// Ignore dark-mode hints if print media.
+@media not print
+  // Enable dark-mode, if requested.
+  body[data-theme="dark"]
     @include colors-dark
 
     html & .only-light
       display: none !important
     .only-dark
       display: block !important
+
+  // Enable dark mode, unless explicitly told to avoid.
+  @media (prefers-color-scheme: dark)
+    body:not([data-theme="light"])
+      @include colors-dark
+
+      html & .only-light
+        display: none !important
+      .only-dark
+        display: block !important
 
 //
 // Theme toggle presentation

--- a/src/furo/theme/furo/partials/_head_css_variables.html
+++ b/src/furo/theme/furo/partials/_head_css_variables.html
@@ -15,12 +15,14 @@
   body {
     {{ declare_css_variables(theme_light_css_variables, furo_pygments.light) }}
   }
-  body[data-theme="dark"] {
-    {{ declare_css_variables(theme_dark_css_variables, furo_pygments.dark) }}
-  }
-  @media (prefers-color-scheme: dark) {
-    body:not([data-theme="light"]) {
+  @media not print {
+    body[data-theme="dark"] {
       {{ declare_css_variables(theme_dark_css_variables, furo_pygments.dark) }}
+    }
+    @media (prefers-color-scheme: dark) {
+      body:not([data-theme="light"]) {
+        {{ declare_css_variables(theme_dark_css_variables, furo_pygments.dark) }}
+      }
     }
   }
 </style>


### PR DESCRIPTION
The following improves the ability to print documentation themed with Furo. This includes hiding various elements (such as the mobile bar) that are not useful in printed media, as well as deals with color scheming issues for browsers who do not default to light scheme in a print media state.

---

These changes also resolve an issue (observed in Chrome/Edge; Firefox is fine) where the printing preview page would think there would be tens of thousands of pages to print:

![image](https://user-images.githubusercontent.com/1834509/143324171-bde7ba4e-4f80-4b4a-b7ca-e63dbe6f1d84.png)
