### PR TITLE
Let page wrapper expand as needed

### DIFF
--- a/src/furo/assets/styles/_scaffold.sass
+++ b/src/furo/assets/styles/_scaffold.sass
@@ -40,7 +40,6 @@ html
 //
 html,
 body
-  height: 100%
   color: var(--color-foreground-primary)
   background: var(--color-background-primary)
 


### PR DESCRIPTION
This line is causing some strangeness. It doesn't seem to be doing this on https://pradyunsg.me/furo/ but in my local build of my docs I'm getting this weirdness when I turn on dark mode:

![2021-12-10-120158_1632x819_scrot](https://user-images.githubusercontent.com/987487/145612713-b7028f28-6534-4609-8c26-74890d4cb61d.png)

simply removing this line fixes the weirdness:

![2021-12-10-120203_1631x803_scrot](https://user-images.githubusercontent.com/987487/145612714-8a0347c5-f654-462b-b6e7-814565ab0593.png)

Do you remember why this line is here in the first place?