### PR TITLE
Add a link for genindex on the sidebar

### DIFF
--- a/src/furo/theme/furo/sidebar/scroll-end.html
+++ b/src/furo/theme/furo/sidebar/scroll-end.html
@@ -1,1 +1,11 @@
+<div class="sidebar-tree" style="margin-top:-1em">
+  <ul>
+    <li class="toctree-l1">
+      <a class="reference internal"
+         href="{{ pathto('genindex') }}">
+         Stichwortverzeichnis
+      </a>
+    </li>
+  </ul>
+</div>
 </div>


### PR DESCRIPTION
As a standard, getting the genindex is placed on the bottom of the top index page.
I like to have a link to the genindex on all pages and include  it at the bottom of the sidebar.
Would be nice, if you like the Idea too. :-)
I missed to find out how to use the translation for unsing genindex, as an example I used the german translation.
 