### PR TITLE
Check for existence of pygments css file before overwriting it

### DIFF
--- a/src/furo/__init__.py
+++ b/src/furo/__init__.py
@@ -361,8 +361,10 @@ def _overwrite_pygments_css(
         return
 
     assert app.builder
-    with open(os.path.join(app.builder.outdir, "_static", "pygments.css"), "w") as f:
-        f.write(get_pygments_stylesheet())
+    pygments_css = Path(app.builder.outdir) / "_static" / "pygments.css"
+    if pygments_css.is_file():
+        with pygments_css.open("w") as f:
+            f.write(get_pygments_stylesheet())
 
 
 def setup(app: sphinx.application.Sphinx) -> Dict[str, Any]:

--- a/src/furo/__init__.py
+++ b/src/furo/__init__.py
@@ -4,7 +4,6 @@ __version__ = "2022.03.04.dev1"
 
 import hashlib
 import logging
-import os
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional


### PR DESCRIPTION
When there is no `pygments.css` files in `_static` (for whatever reason, see below for more context), then furo's `build_finished` hook fails with the following error:
```
Handler <function _overwrite_pygments_css at 0x7fdd1d8aeee0> for event 'build-finished' threw an exception (exception: [Errno 2] No such file or directory: '/sage/local/share/doc/sage/inventory/en/reference/_static/pygments.css')
```
This is fixed by first checking for the existence of this file, before we attempt to overwrite it.

Context: In sage, we use a custom html builder that preprocesses the documentation files and extracts inventory files for intersphinx (see https://github.com/sagemath/sage/blob/develop/src/sage_docbuild/ext/inventory_builder.py). In this preprocessing step, we don't generate any html and also don't have a `_static` directory.
