### PR TITLE
Add rel="canonical" based on `html_baseurl` configuration

### DIFF
--- a/src/furo/theme/furo/base.html
+++ b/src/furo/theme/furo/base.html
@@ -27,6 +27,10 @@
         {%- if prev -%}
           <link rel="prev" title="{{ prev.title|striptags|e }}" href="{{ prev.link|e }}" />
         {%- endif -%}
+        {#- rel="canonical" (set by html_baseurl) -#}
+        {%- if pageurl %}
+        <link rel="canonical" href="{{ pageurl|e }}" />
+        {%- endif %}
     {%- endblock linktags %}
 
     {# Favicon #}


### PR DESCRIPTION
Fixes #410 

I tried adding this to the furo docs as well, but it doesn't work because the
Furo docs URLs are like https://pradyunsg.me/furo/recommendations/ instead of
https://pradyunsg.me/furo/recommendations.html.
