### PR TITLE
Add accessible name to 'Edit this page' icon

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.6.1
+    rev: v2.6.2
     hooks:
       - id: prettier
         exclude: src/furo/theme/.*|docs/(recommendations|reference/admonitions).md
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3.8

--- a/src/furo/theme/furo/page.html
+++ b/src/furo/theme/furo/page.html
@@ -70,12 +70,13 @@
           {#- Edit this page, on GitHub -#}
           {%- if READTHEDOCS and conf_py_path and page_source_suffix and github_user != "None" and github_repo != "None" and github_version %}
           <div class="edit-this-page">
-            <a class="muted-link" href="https://github.com/{{ github_user }}/{{ github_repo }}/edit/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ page_source_suffix }}">
-              <svg viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+            <a class="muted-link" href="https://github.com/{{ github_user }}/{{ github_repo }}/edit/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ page_source_suffix }}" title="Edit this page">
+              <svg aria-hidden="true" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                 <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
                 <path d="M4 20h4l10.5 -10.5a1.5 1.5 0 0 0 -4 -4l-10.5 10.5v4" />
                 <line x1="13.5" y1="6.5" x2="17.5" y2="10.5" />
               </svg>
+              <span class="visually-hidden">Edit this page</span>
             </a>
           </div>
           {% endif %}

--- a/src/furo/theme/furo/page.html
+++ b/src/furo/theme/furo/page.html
@@ -70,13 +70,13 @@
           {#- Edit this page, on GitHub -#}
           {%- if READTHEDOCS and conf_py_path and page_source_suffix and github_user != "None" and github_repo != "None" and github_version %}
           <div class="edit-this-page">
-            <a class="muted-link" href="https://github.com/{{ github_user }}/{{ github_repo }}/edit/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ page_source_suffix }}" title="Edit this page">
+            <a class="muted-link" href="https://github.com/{{ github_user }}/{{ github_repo }}/edit/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ page_source_suffix }}" title="{{ _("Edit this page") }}">
               <svg aria-hidden="true" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                 <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
                 <path d="M4 20h4l10.5 -10.5a1.5 1.5 0 0 0 -4 -4l-10.5 10.5v4" />
                 <line x1="13.5" y1="6.5" x2="17.5" y2="10.5" />
               </svg>
-              <span class="visually-hidden">Edit this page</span>
+              <span class="visually-hidden">{{ _("Edit this page") }}</span>
             </a>
           </div>
           {% endif %}


### PR DESCRIPTION
Running [Lighthouse](https://web.dev/measure/) on https://pillow.readthedocs.io/en/latest/ gives a good accessibility score with one suggestion:

![image](https://user-images.githubusercontent.com/1324225/161581901-68a4f30c-b66b-46ea-bc90-1902c6fc405b.png)

For the edit icon:

> Link text (and alternate text for images, when used as links) that is discernible, unique, and focusable improves the navigation experience for screen reader users. [Learn more](https://web.dev/link-name/?utm_source=lighthouse&utm_medium=lr).

Here's a suggestion, following https://kittygiraudel.com/2020/12/10/accessible-icon-links/

* Add `<span class="visually-hidden">Edit this page</span>` after the SVG, hidden but accessible
* Add `aria-hidden="true"` to the `<svg>` to remove it from the accessibility tree
* Addd `title="Edit this page` to the `<a>`, not strictly necessary but gives a tooltip
* I didn't bother with the IE tip as it's almost gone (https://death-to-ie11.com) but let me know if you'd like it

