### PR TITLE
Allow GitHub edit link without read-the-docs

### DIFF
--- a/src/furo/theme/furo/page.html
+++ b/src/furo/theme/furo/page.html
@@ -170,7 +170,7 @@
               </a>
               {%- endif -%}
               {#- Show GitHub repository home -#}
-              {%- if READTHEDOCS and display_github and github_user != "None" and github_repo != "None" -%}
+              {%- if display_github and github_user != "None" and github_repo != "None" -%}
               <a class="muted-link" href="https://github.com/{{ github_user }}/{{ github_repo }}" aria-label="On GitHub">
                 <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 16 16">
                   <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>


### PR DESCRIPTION
The edit link widget works perfectly fine in producing GitHub URLs in the absence of an RTD context. Proof: nowhere in the code the widget there is reference to the `READTHEDOCS` variable.

This change allow the production of GitHub edit links without having to set `READTHEDOCS` to `True`, which has the side effect of [activating the variant widget](https://github.com/pradyunsg/furo/blob/fe4f866f9db31543e72c796d092e92e813769bd9/src/furo/theme/furo/sidebar/variant-selector.html#L2) for non-RTD hosted documentation.

For the context, this issue has been identified while working on [`meta-package-manager` documentation](https://github.com/kdeldycke/meta-package-manager/commit/3b1632d45becbffeac094291199bd9e25acf304e).

And Here is the resulting spurious variant widget that will be silenced by this change:
<img width="270" alt="Screen Shot 2022-04-21 at 13 28 00" src="https://user-images.githubusercontent.com/159718/164425049-a21ea929-136a-496c-91ef-10add7805bbb.png">


