### PR TITLE
Added the ability to make the previous and next buttons hidden.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,10 @@ https://en.wikipedia.org/wiki/Lists_of_colors
 
 -->
 
+## 2022.05.29 -- Noble Nyanza
+
+- Add ability to hide previous and next buttons
+
 ## 2022.04.07 -- Magical Mauve
 
 - ✨ Make sphinx-copybutton look better.

--- a/docs/customisation/edit-button.md
+++ b/docs/customisation/edit-button.md
@@ -6,9 +6,9 @@ This is automatically added, when the documentation is generated on Read the Doc
 
 ```python
 html_theme_options = {
-  "source_repository": "https://github.com/pradyunsg/furo/",
-  "source_branch": "main",
-  "source_directory": "docs/",
+    "source_repository": "https://github.com/pradyunsg/furo/",
+    "source_branch": "main",
+    "source_directory": "docs/",
 }
 ```
 

--- a/docs/customisation/index.md
+++ b/docs/customisation/index.md
@@ -71,6 +71,7 @@ html_theme_options = {
 ```
 
 (top_of_page_button)=
+
 ### `top_of_page_button`
 
 Controls which button is shown on the top of the page. The only supported values are `"edit"` (the default) and `None`.

--- a/src/furo/theme/furo/page.html
+++ b/src/furo/theme/furo/page.html
@@ -93,6 +93,7 @@
       </div>
       <footer>
         {% block footer %}
+        {%- if (theme_prev_next_buttons != 'hidden') %}
         <div class="related-pages">
           {% if next -%}
             <a class="next-page" href="{{ next.link }}">
@@ -121,6 +122,7 @@
             </a>
           {%- endif %}
         </div>
+        {%- endif %}
         <div class="bottom-of-page">
           <div class="left-details">
             {%- if show_copyright %}

--- a/src/furo/theme/furo/theme.conf
+++ b/src/furo/theme/furo/theme.conf
@@ -22,7 +22,7 @@ light_logo =
 sidebar_hide_name =
 footer_icons =
 top_of_page_button = edit
-prev_next_buttons = 
+prev_next_buttons =
 # For components/edit-this-page.html
 source_repository =
 source_branch =

--- a/src/furo/theme/furo/theme.conf
+++ b/src/furo/theme/furo/theme.conf
@@ -22,6 +22,7 @@ light_logo =
 sidebar_hide_name =
 footer_icons =
 top_of_page_button = edit
+prev_next_buttons = 
 # For components/edit-this-page.html
 source_repository =
 source_branch =


### PR DESCRIPTION
I wanted to remove the previous and next buttons. I ported over the implementation as shown in Sphinx Read the Docs theme. The html theme option is prev_next_buttons with possible choice of hidden. If it isn't set to hidden they will be shown.