### PR TITLE
Replace deprecated logging.warn with logging.warning

### DIFF
--- a/src/furo/__init__.py
+++ b/src/furo/__init__.py
@@ -324,7 +324,7 @@ def _get_dark_style(app: sphinx.application.Sphinx) -> Style:
         ):
             dark_style = app.config._raw_config["pygments_dark_style"]
     except (AttributeError, KeyError) as e:
-        logger.warn(
+        logger.warning(
             (
                 "Furo could not determine the value of `pygments_dark_style`. "
                 "Falling back to using the value provided by Sphinx.\n"


### PR DESCRIPTION
Replace `logging.warn` (deprecated in [Python 2.7, 2011](https://github.com/python/cpython/commit/04d5bc00a219860c69ea17eaa633d3ab9917409f)) with `logging.warning` (added in [Python 2.3, 2003](https://github.com/python/cpython/commit/6fa635df7aa88ae9fd8b41ae42743341316c90f7)).

* https://docs.python.org/3/library/logging.html#logging.Logger.warning
* https://github.com/python/cpython/issues/57444
