### PR TITLE
Fix left padding for `.sig-inline`

### DIFF
--- a/src/furo/assets/styles/content/_api.sass
+++ b/src/furo/assets/styles/content/_api.sass
@@ -82,6 +82,8 @@ em.property
   color: var(--color-api-paren)
 .sig-param
   font-style: normal
+.sig-inline
+  padding-left: 0.5rem
 
 .versionmodified
   font-style: italic


### PR DESCRIPTION
Fixes: #486