### PR TITLE
[WIP] Version selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ node_modules
 /build
 /dist
 __pycache__
+env/
+
+*.sw[a-p]

--- a/src/furo/assets/styles/extensions/_readthedocs.sass
+++ b/src/furo/assets/styles/extensions/_readthedocs.sass
@@ -1,11 +1,13 @@
 // This file contains the styles used for tweaking how ReadTheDoc's embedded
 // contents would show up inside the theme.
 
-#furo-versions 
+#furo-versions
   .latest-version
     font-weight: bold
+
+  .current-version
+    font-weight: bold
     font-size: 1.5em
-    text-decoration: underline
 
 #furo-sidebar-ad-placement
   padding: var(--sidebar-item-spacing-vertical) var(--sidebar-item-spacing-horizontal)

--- a/src/furo/assets/styles/extensions/_readthedocs.sass
+++ b/src/furo/assets/styles/extensions/_readthedocs.sass
@@ -9,8 +9,14 @@
 
   .current-version
     font-weight: bold
-    font-size: 1.5em
-    list-style-type: "⇛"
+    //font-size: 1.5em
+    list-style-type: "⇛ "
+
+  .caption
+    color: var(--color-sidebar-caption-text)
+    font-weight: bold
+    text-transform: uppercase
+    font-size: var(--sidebar-caption-font-size)
 
 #furo-sidebar-ad-placement
   padding: var(--sidebar-item-spacing-vertical) var(--sidebar-item-spacing-horizontal)

--- a/src/furo/assets/styles/extensions/_readthedocs.sass
+++ b/src/furo/assets/styles/extensions/_readthedocs.sass
@@ -10,7 +10,7 @@
   .current-version
     font-weight: bold
     font-size: 1.5em
-    list-style-type: "\11"
+    list-style-type: "⇛"
 
 #furo-sidebar-ad-placement
   padding: var(--sidebar-item-spacing-vertical) var(--sidebar-item-spacing-horizontal)

--- a/src/furo/assets/styles/extensions/_readthedocs.sass
+++ b/src/furo/assets/styles/extensions/_readthedocs.sass
@@ -2,12 +2,15 @@
 // contents would show up inside the theme.
 
 #furo-versions
+  font-size: var(--sidebar-item-font-size)
+
   .latest-version
     font-weight: bold
 
   .current-version
     font-weight: bold
     font-size: 1.5em
+    list-style-type: "\11"
 
 #furo-sidebar-ad-placement
   padding: var(--sidebar-item-spacing-vertical) var(--sidebar-item-spacing-horizontal)

--- a/src/furo/assets/styles/extensions/_readthedocs.sass
+++ b/src/furo/assets/styles/extensions/_readthedocs.sass
@@ -1,6 +1,12 @@
 // This file contains the styles used for tweaking how ReadTheDoc's embedded
 // contents would show up inside the theme.
 
+#furo-versions 
+  .latest-version
+    font-weight: bold
+    font-size: 1.5em
+    text-decoration: underline
+
 #furo-sidebar-ad-placement
   padding: var(--sidebar-item-spacing-vertical) var(--sidebar-item-spacing-horizontal)
   .ethical-sidebar

--- a/src/furo/theme/furo/sidebar/variant-selector.html
+++ b/src/furo/theme/furo/sidebar/variant-selector.html
@@ -32,11 +32,11 @@
 </div>
 {% elif versions %}
 <div id="furo-versions" class="rst-versions" role="note" aria-label="{{ _('Versions') }}" tabindex="0">
-  <p>Versions</p>
+  <p class="caption">Versions</p>
   <ul>
-    <li class="latest-version">Latest: <a href="{{ latest_version.url }}">{{ latest_version.name }}</a></li>
+    {#<li class="latest-version">Latest: <a href="{{ latest_version.url }}">{{ latest_version.name }}</a></li>#}
   {% for version in versions|reverse -%}
-  <li{% if version.name == current_version.name %} class="current-version"{%- endif %}><a href="{{ version.url }}">{{ version.name }}</a></li>
+  <li{% if version.name == current_version.name %} class="current-version"{%- endif %}>{% if version.name == latest_version.name -%}<b>Latest: </b>{%- endif %}<a href="{{ version.url }}">{{ version.name }}</a></li>
   {% endfor -%}
   </ul>
 </div>

--- a/src/furo/theme/furo/sidebar/variant-selector.html
+++ b/src/furo/theme/furo/sidebar/variant-selector.html
@@ -35,7 +35,7 @@
   <p>Versions</p>
   <ul>
   {% for version in versions -%}
-  <li{% if version.name == latest_version.name %} class="latest-version"{%- elif version.name == current_version.name %} class="current-version"{%- endif %}><a href="{{ version.url }}">{{ version.name }}</a></li>
+  <li{% if version.name == current_version.name %} class="current-version"{%- elif version.name == latest_version.name %} class="latest-version"{%- endif %}><a href="{{ version.url }}">{{ version.name }}</a></li>
   {% endfor -%}
   </ul>
 </div>

--- a/src/furo/theme/furo/sidebar/variant-selector.html
+++ b/src/furo/theme/furo/sidebar/variant-selector.html
@@ -35,7 +35,7 @@
   <p>Versions</p>
   <ul>
   {% for version in versions -%}
-  <li {%- if version.name == latest_version.name %} class="latest-version"{%- endif %}><a href="{{ version.url }}">{{ version.name }}</a></li>
+  <li{% if version.name == latest_version.name %} class="latest-version"{%- elif version.name == current_version.name %} class="current-version"{%- endif %}><a href="{{ version.url }}">{{ version.name }}</a></li>
   {% endfor -%}
   </ul>
 </div>

--- a/src/furo/theme/furo/sidebar/variant-selector.html
+++ b/src/furo/theme/furo/sidebar/variant-selector.html
@@ -30,4 +30,17 @@
     </dl>
   </div>
 </div>
+{% elif versions %}
+<div id="furo-versions" class="rst-versions" role="note" aria-label="{{ _('Versions') }}" tabindex="0">
+  <p>Versions</p>
+  <ul>
+  {% for version in versions -%}
+  <li {%- if version.name == latest_version.name %} class="latest-version"{%- endif %}><a href="{{ version.url }}">{{ version.name }}</a></li>
+  {% endfor -%}
+  </ul>
+</div>
 {% endif %}
+{#
+latest: {{ latest_version }}
+current: {{ current_version }}
+#}

--- a/src/furo/theme/furo/sidebar/variant-selector.html
+++ b/src/furo/theme/furo/sidebar/variant-selector.html
@@ -34,8 +34,9 @@
 <div id="furo-versions" class="rst-versions" role="note" aria-label="{{ _('Versions') }}" tabindex="0">
   <p>Versions</p>
   <ul>
-  {% for version in versions -%}
-  <li{% if version.name == current_version.name %} class="current-version"{%- elif version.name == latest_version.name %} class="latest-version"{%- endif %}><a href="{{ version.url }}">{{ version.name }}</a></li>
+    <li class="latest-version">Latest: <a href="{{ latest_version.url }}">{{ latest_version.name }}</a></li>
+  {% for version in versions|reverse -%}
+  <li{% if version.name == current_version.name %} class="current-version"{%- endif %}><a href="{{ version.url }}">{{ version.name }}</a></li>
   {% endfor -%}
   </ul>
 </div>


### PR DESCRIPTION
I definitely plan to do a rebase to clean up this commit history (probably end out just squashing to one commit) before I'm done with this as a draft status.

But this is my PoC for #372, and the [instructions](https://github.com/pradyunsg/furo/issues/372#issuecomment-1192955534) I dropped in there should work here as well.

The things that I'm pretty sure I should do differently are around where to put my styles, as well as perhaps some of the naming(s) that I used. I can possibly do some cleanup with the code/jinja in variant-selector (obviously there's still some debugging code in there that'll need to be removed).

Here's what it currently looks like with the latest version selected:

![image](https://user-images.githubusercontent.com/189750/183160632-5662cb11-0595-4d80-b1ed-8d70c4d05bfa.png)

And with a different version selected:

![image](https://user-images.githubusercontent.com/189750/183160714-5209b0af-6283-4fad-885b-16760b8986d3.png)

One thought I had was to change up the behavior a bit to make it match with the drop-down styling found in the top bar. I also just now thought it looked a bit busy with the list, and I kind of like it using a `list-style: none`:

![image](https://user-images.githubusercontent.com/189750/183161400-8abb3c65-005a-4237-adfd-fdfa9f5ddf9a.png)

Any thoughts? 