### PR TITLE
Improve mobile compatibility

### DIFF
--- a/src/furo/assets/styles/_scaffold.sass
+++ b/src/furo/assets/styles/_scaffold.sass
@@ -50,8 +50,8 @@ article
 
 .page
   display: flex
-  // fill the viewport for pages with little content.
-  min-height: 100%
+  height: 100vh
+  overflow-y: hidden
 
 .mobile-header
   width: 100%
@@ -79,7 +79,13 @@ article
 
 .main
   display: flex
-  flex: 1
+  overflow-y: scroll
+
+  position: relative
+  top: 0
+  bottom: 0
+  right: 0
+  left: 0
 
 // Sidebar (left) also covers the entire left portion of screen.
 .sidebar-drawer
@@ -272,7 +278,8 @@ article
     .sidebar-drawer
       top: 0
       left: 0
-      // Show the toc sidebar
+
+// Show the toc sidebar
 #__toc:checked
   & ~ .toc-overlay
     width: 100%
@@ -380,6 +387,8 @@ article
       label
         height: 100%
         width: 100%
+
+        user-select: none
 
   // Add a scroll margin for the content
   :target

--- a/src/furo/assets/styles/components/_sidebar.sass
+++ b/src/furo/assets/styles/components/_sidebar.sass
@@ -154,6 +154,7 @@
     width: var(--sidebar-expander-width)
 
     cursor: pointer
+    user-select: none
 
     display: flex
     justify-content: center

--- a/src/furo/theme/furo/page.html
+++ b/src/furo/theme/furo/page.html
@@ -184,24 +184,24 @@
         {% endblock footer %}
       </footer>
     </div>
-    <aside class="toc-drawer{% if furo_hide_toc %} no-toc{% endif %}">
-      {% block right_sidebar %}
-      {% if not furo_hide_toc %}
-      <div class="toc-sticky toc-scroll">
-        <div class="toc-title-container">
-          <span class="toc-title">
-            {{ _("On this page") }}
-          </span>
-        </div>
-        <div class="toc-tree-container">
-          <div class="toc-tree">
-            {{ toc }}
-          </div>
+  </div>
+  <aside class="toc-drawer{% if furo_hide_toc %} no-toc{% endif %}">
+    {% block right_sidebar %}
+    {% if not furo_hide_toc %}
+    <div class="toc-sticky toc-scroll">
+      <div class="toc-title-container">
+        <span class="toc-title">
+          {{ _("On this page") }}
+        </span>
+      </div>
+      <div class="toc-tree-container">
+        <div class="toc-tree">
+          {{ toc }}
         </div>
       </div>
-      {% endif %}
-      {% endblock right_sidebar %}
-    </aside>
-  </div>
+    </div>
+    {% endif %}
+    {% endblock right_sidebar %}
+  </aside>
 </div>
 {%- endblock %}


### PR DESCRIPTION
This PR fixes 2 issues that have been bugging me for a while when viewing docs on mobile:
- `user-select: none`: for some reason clicking on some buttons selected it, this just disabled it :)
- Other changes: A bit of moving around to prevent scrolling while one of the sidebars is open (navegation and TOC).

*I am nowhere proficient at HTML and CSS and this solution I came up with seems hacky, but I cant find a better way that doesnt break the site in one way or another. If there is a better suggestion, I will make sure to test and update the PR to match that!*