### PR TITLE
Add `source_edit_link` as supported theme configuration parameter

### DIFF
--- a/src/furo/theme/furo/theme.conf
+++ b/src/furo/theme/furo/theme.conf
@@ -26,3 +26,4 @@ top_of_page_button = edit
 source_repository =
 source_branch =
 source_directory =
+source_edit_link =


### PR DESCRIPTION
This was necessary to avoid the below message, and generate the edit button correctly pointing to a custom gitlab instance
```
preparing documents... WARNING: unsupported theme option 'source_edit_link' given
```

This fix (and especially this theme) works nicely for our doc site!