### PR TITLE
Fix read/reader typo

### DIFF
--- a/docs/kitchen-sink/generic.rst
+++ b/docs/kitchen-sink/generic.rst
@@ -62,7 +62,7 @@ GUI labels should not run over line height.
 Keys / Menu labels
 ^^^^^^^^^^^^^^^^^^
 
-Key-bindings indicate that the read is to press a button on the keyboard or
+Key-bindings indicate that the reader is to press a button on the keyboard or
 mouse, for example :kbd:`MMB`, :kbd:`⌘+⇧+M` and :kbd:`Shift-MMB`. Another
 useful way is ``menuselection`` to show menus:
 :menuselection:`My --> Software --> Some menu --> Some sub menu 1 --> Some sub menu 2 --> Some sub menu 3`


### PR DESCRIPTION
Hi,

I think this is a typo - thought I'd open a PR to fix it if so.

Another option would be to write `user` instead of `read`/`reader` since the `GUI labels` section immediately above uses `user`, so it might be more consistent to use the same term in both places to refer to the user/reader (or alternatively, switch `user` for `reader` in the other section).

While I'm here, thanks for Furo, it's great!