### PR TITLE
Print CSS: avoid page break in some relevant cases

### DIFF
--- a/src/furo/assets/styles/base/_print.sass
+++ b/src/furo/assets/styles/base/_print.sass
@@ -34,7 +34,7 @@
 @media print
   ul, ol, dl, a, table, pre, blockquote
     page-break-inside: avoid
-  
+
   h1, h2, h3, h4, h5, h6, img, figure, caption
     page-break-inside: avoid
     page-break-after: avoid

--- a/src/furo/assets/styles/base/_print.sass
+++ b/src/furo/assets/styles/base/_print.sass
@@ -27,3 +27,17 @@
   // Apply a border around code which no longer have a color background.
   .highlight
     border: 0.1pt solid var(--color-foreground-border)
+
+////////////////////////////////////////////////////////////////////////////////
+// Avoid page break in some relevant cases.
+////////////////////////////////////////////////////////////////////////////////
+@media print
+  ul, ol, dl, a, table, pre, blockquote
+    page-break-inside: avoid
+  
+  h1, h2, h3, h4, h5, h6, img, figure, caption
+    page-break-inside: avoid
+    page-break-after: avoid
+
+  ul, ol, dl
+    page-break-before: avoid


### PR DESCRIPTION
While printing a Sphinx documentation page as PDF, I noticed a simple list (`<ul>`) was separated on two successive pages. I think simple CSS print rules could improve that kind of issues.

Inspiration source: https://www.alsacreations.com/astuce/lire/1160-une-feuille-de-styles-de-base-pour-le-media-print.html

Please note that I'm not fluent with the indented Sass syntax. 