### PR TITLE
Support MyST table column alignment

### DIFF
--- a/src/furo/assets/styles/content/_tables.sass
+++ b/src/furo/assets/styles/content/_tables.sass
@@ -32,3 +32,11 @@ table.docutils
       border-left: none
     &:last-child
       border-right: none
+    
+    // MyST tables set these classes for control of column alignment
+    &:.text-left
+      text-align: left
+    &:.text-right
+      text-align: right
+    &:.text-center
+      text-align: center

--- a/src/furo/assets/styles/content/_tables.sass
+++ b/src/furo/assets/styles/content/_tables.sass
@@ -32,7 +32,7 @@ table.docutils
       border-left: none
     &:last-child
       border-right: none
-    
+
     // MyST tables set these classes for control of column alignment
     &:.text-left
       text-align: left


### PR DESCRIPTION
With Markdown tables, one can control column alignment:

```markdown
| left | center | right |
| :--- | :----: | ----: |
| a    | b      | c     |
```

To enable this non-standard (in docutils) feature, MyST-Parser adds CSS classes to the `td`/`th`, which then require implementation by the HTML themes.