### PR TITLE
Break long inline code literals

### DIFF
--- a/docs/kitchen-sink/generic.rst
+++ b/docs/kitchen-sink/generic.rst
@@ -73,7 +73,7 @@ single line.
 Long inline code wrapping
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. DO NOT RE-WRAP THE FOLLOWING PARAGRAPH!
+.. DO NOT RE-WRAP THE FOLLOWING PARAGRAPHS!
 
 Let's test wrapping and whitespace significance in inline literals:
 ``This is an example of --inline-literal --text, --including some--
@@ -81,6 +81,10 @@ strangely--hyphenated-words.  Adjust-the-width-of-your-browser-window
 to see how the text is wrapped.  -- ---- --------  Now note    the
 spacing    between the    words of    this sentence    (words
 should    be grouped    in pairs).``
+
+A very long "word": ``LoremipsumdolorsitametconsetetursadipscingelitrseddiamnonumyeirmodtemporinviduntutlaboreetdoloremagnaaliquyameratseddiamvoluptuaAtveroeosetaccusametjustoduodoloresetearebum``
+
+A very long path: ``/my/network/directory/where/all/my/fancy/files/reside/but/I/tend/to/hide/them/in/very/long/subdirectories/to/keep/them/very/hard/to/find/even/for/myself.exe``
 
 Math
 ====

--- a/src/furo/assets/styles/content/_code.sass
+++ b/src/furo/assets/styles/content/_code.sass
@@ -6,6 +6,8 @@ code.literal, .sig-inline
   font-size: var(--font-size--small--2)
   padding: 0.1em 0.2em
 
+  overflow-wrap: break-word
+
   p &
     border: 1px solid var(--color-background-border)
 


### PR DESCRIPTION
Inline code is currently only broken on "normal"
word break opportunities. Unfortunately, it depends
on the browser engine what "normal" word break
opportunities mean. This becomes very visible in
a typical example for a long inline string: a long
Unix-style path or an URL. Firefox considers a slash
("/") a word break opportunity, while Chrome doesn't.

To keep documentation readable we need to break long
inline code literals, otherwise they expand beyond
the viewport where they are of little use to the
reader.

Introducing "overflow-wrap: break-word" gives us
line-breaking in all browsers, even though the rendered
result will differ depending on the browser in question.

## Before
### Chrome
![before-chrome](https://user-images.githubusercontent.com/1467123/195557685-68e80044-9164-499c-bf25-c60d69b5178a.png)

### Firefox
![before-firefox](https://user-images.githubusercontent.com/1467123/195557692-5bfaf27f-ad23-42b5-be2d-4f70a2a49cc4.png)


## After
### Chrome
![after-chrome](https://user-images.githubusercontent.com/1467123/195557694-ea48c651-588b-4f52-a48b-2515c48a303f.png)
### Firefox
![after-firefox](https://user-images.githubusercontent.com/1467123/195557696-a4bea3a5-8463-4ea7-b375-3b7faeb711e4.png)
