### PR TITLE
Increase icon sizes

### DIFF
--- a/src/furo/assets/styles/_scaffold.sass
+++ b/src/furo/assets/styles/_scaffold.sass
@@ -186,14 +186,14 @@ article
 
 .theme-toggle svg
   vertical-align: middle
-  height: 1rem
-  width: 1rem
+  height: 1.5rem
+  width: 1.5rem
   color: var(--color-foreground-primary)
   display: none
 
 .theme-toggle-header
   float: left
-  padding: 1rem 0.5rem
+  padding: .75rem 0.5rem
 
 ////////////////////////////////////////////////////////////////////////////////
 // Toggles for elements
@@ -204,8 +204,8 @@ article
 
   .icon
     color: var(--color-foreground-secondary)
-    height: 1rem
-    width: 1rem
+    height: 1.5rem
+    width: 1.5rem
 
 .toc-header-icon, .nav-overlay-icon
   // for when we set display: flex
@@ -226,8 +226,8 @@ article
 
   .edit-this-page svg
     color: inherit
-    height: 1rem
-    width: 1rem
+    height: 1.5rem
+    width: 1.5rem
 
 .sidebar-toggle
   position: absolute

--- a/src/furo/assets/styles/components/_footer.sass
+++ b/src/furo/assets/styles/components/_footer.sass
@@ -48,7 +48,7 @@ footer
 
     svg,
     img
-      font-size: 1.125rem
+      font-size: 1.75rem
       height: 1em
       width: 1em
 

--- a/src/furo/assets/styles/components/_footer.sass
+++ b/src/furo/assets/styles/components/_footer.sass
@@ -40,7 +40,7 @@ footer
   .icons
     display: flex
     justify-content: flex-end
-    gap: 0.25rem
+    gap: 0.5rem
     font-size: 1rem
 
     a

--- a/src/furo/assets/styles/variables/_spacing.scss
+++ b/src/furo/assets/styles/variables/_spacing.scss
@@ -8,7 +8,7 @@
   --header-height: calc(
     var(--sidebar-item-line-height) + 4 * #{var(--sidebar-item-spacing-vertical)}
   );
-  --header-padding: 0.5rem;
+  --header-padding: 1rem;
 
   // Sidebar
   --sidebar-tree-space-above: 1.5rem;


### PR DESCRIPTION
# Description
This PR increases the size of some icons in order to improve accessibility, particularly for mobile devices. The larger sizes only consume a slightly larger horizontal width, while the vertical width is mainly unchanged due to padding/margin - which is great, because it only takes up previously empty space. I've included some before/after comparison images below.

# Rationale
I've found that on mobile the menu icons are harder to tap than they should be, and compared to honestly most other websites the proportions just look and feel unnatural. I've even had difficulty clicking the icons on desktop sometimes. These new sizes make the site feel more modern and easy to use.

<details open>
<summary><h2>Mobile</h2></summary>

### Header
- Before
  <img width="389" alt="Screen Shot 2022-10-15 at 7 52 55 PM" src="https://user-images.githubusercontent.com/71356958/196012858-71912d25-ff53-4e31-8806-2b7ea83f3d17.png">
- After
  <img width="383" alt="Screen Shot 2022-10-15 at 7 53 24 PM" src="https://user-images.githubusercontent.com/71356958/196012883-2cf43d1b-4928-45cf-9768-ed95064e5688.png">


### Footer
- Before
  <img width="381" alt="Screen Shot 2022-10-15 at 7 54 10 PM" src="https://user-images.githubusercontent.com/71356958/196012897-23a6aaa7-85c3-4e63-bb4c-ee5ea12d2d4e.png">
- After
  <img width="380" alt="Screen Shot 2022-10-15 at 7 54 57 PM" src="https://user-images.githubusercontent.com/71356958/196012915-79e93316-1f33-465b-a760-f6e8a523b65b.png">
</details>
<details>
<summary><h2>Desktop</h2></summary>

### Header (Wide)
- Before
  <img width="1440" alt="Screen Shot 2022-10-15 at 6 43 04 PM" src="https://user-images.githubusercontent.com/71356958/196011473-04c36ba3-4cec-4d6b-adb0-be6c7b408dfd.png">
- After
  <img width="1437" alt="Screen Shot 2022-10-15 at 6 44 14 PM" src="https://user-images.githubusercontent.com/71356958/196011505-448a6284-8d20-48db-9fc8-d933790dc4bb.png">

### Header (Narrow)
- Before
  <img width="1038" alt="Screen Shot 2022-10-15 at 7 49 53 PM" src="https://user-images.githubusercontent.com/71356958/196012779-c0229e5b-220c-4c21-b067-f81821c7d4dc.png">

- After
  <img width="1055" alt="Screen Shot 2022-10-15 at 7 50 23 PM" src="https://user-images.githubusercontent.com/71356958/196012781-f94df612-4107-4b2d-b10c-d109542512b5.png">

### Footer
- Before
  <img width="809" alt="Screen Shot 2022-10-15 at 6 45 57 PM" src="https://user-images.githubusercontent.com/71356958/196011545-1f8d3a24-2258-4e64-87f1-c243eb8a0e79.png">
- After
  <img width="816" alt="Screen Shot 2022-10-15 at 6 46 26 PM" src="https://user-images.githubusercontent.com/71356958/196011553-8ef682eb-1843-4399-b506-e2daecb79311.png">
</details>