### PR TITLE
Increase admonition title background opacity

### DIFF
--- a/src/furo/assets/styles/variables/_admonitions.scss
+++ b/src/furo/assets/styles/variables/_admonitions.scss
@@ -25,14 +25,14 @@ $admonitions: (
 
 @mixin default-admonition($color, $icon-name) {
   --color-admonition-title: #{$color};
-  --color-admonition-title-background: #{rgba($color, 0.1)};
+  --color-admonition-title-background: #{rgba($color, 0.2)};
 
   --icon-admonition-default: var(--icon-#{$icon-name});
 }
 
 @mixin default-topic($color, $icon-name) {
   --color-topic-title: #{$color};
-  --color-topic-title-background: #{rgba($color, 0.1)};
+  --color-topic-title-background: #{rgba($color, 0.2)};
 
   --icon-topic-default: var(--icon-#{$icon-name});
 }
@@ -42,7 +42,7 @@ $admonitions: (
     --color-admonition-title--#{$name}: #{nth($values, 1)};
     --color-admonition-title-background--#{$name}: #{rgba(
         nth($values, 1),
-        0.1
+        0.2
       )};
   }
 }


### PR DESCRIPTION
# Description
This PR increases the admonition title background opacity from 10% to 20%, resulting in a more vibrant mood and smoother contrast. If desired this value could even be raised to 25 or even 30 percent, although that may draw more attention than wanted. 

# Rationale
Currently, admonition title backgrounds are quite dark. When compared to the 100% opacity left border, there is a high contrast that looks out of place upon further inspection. The current opacity doesn't give enough overall contrast to the document as a whole, and therefore doesn't draw as much attention as you would expect from an admonition. Increasing the background opacity decreases the sharp contrast between the border and background, while increasing the overall contrast just enough to draw the eye to land on the admonition title, but doesn't draw the eye too much as to disrupt the flow of the document. Overall, it gives admonitions (particularly warnings and danger messages) the importance they deserve without seeming out of place.