### PR TITLE
Support Sphinx 6.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
   "beautifulsoup4",
-  "sphinx >= 4.0,<6.0",
+  "sphinx >= 5.0,<7.0",
   "sphinx-basic-ng",
   "pygments >= 2.7",
 ]


### PR DESCRIPTION
Apparently the Furo template is not affected by removal of the JS libraries.

Fixes: #556.