### PR TITLE
Revert "Document that GCC is using Furo! (#575)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ A ferret is actually a really good spirit animal for this project: cute, small, 
 - [psycopg3] -- another of the early adopters!
 - [black]
 - [pelican] -- the first Python static site generator adopter!
-- [GCC] -- the GNU Compiler Collection
 
 [urllib3]: https://urllib3.readthedocs.io/
 [attrs]: https://www.attrs.org/
@@ -99,7 +98,6 @@ A ferret is actually a really good spirit animal for this project: cute, small, 
 [psycopg3]: https://www.psycopg.org/psycopg3/docs/
 [black]: https://black.readthedocs.io/en/stable/
 [pelican]: https://docs.getpelican.com/en/latest/
-[gcc]: https://gcc.gnu.org/onlinedocs/gcc/
 
 <!-- end used-by -->
 


### PR DESCRIPTION
This reverts commit 25ddcf19a165584432f6fbe685a66d2104434927.

Unfortunatelly, we won't use Sphinx in GCC documentation for the future.