### PR TITLE
Allow HTML in the copyright message

### DIFF
--- a/src/furo/theme/furo/page.html
+++ b/src/furo/theme/furo/page.html
@@ -126,11 +126,11 @@
             {%- if show_copyright %}
             <div class="copyright">
               {%- if hasdoc('copyright') %}
-                {% trans path=pathto('copyright'), copyright=copyright|e -%}
+                {% trans path=pathto('copyright'), copyright=copyright|safe -%}
                   <a href="{{ path }}">Copyright</a> &#169; {{ copyright }}
                 {%- endtrans %}
               {%- else %}
-                {% trans copyright=copyright|e -%}
+                {% trans copyright=copyright|safe -%}
                   Copyright &#169; {{ copyright }}
                 {%- endtrans %}
               {%- endif %}


### PR DESCRIPTION
It would be nice to allow HTML in the copyright so that you can link to a website, like so:

```python
copyright = "<a href=\"https://jareddillard.com\">Jared Dillard</a>"
```

![Screenshot from 2022-12-22 23-00-44](https://user-images.githubusercontent.com/3474095/209288959-eb6d6bb0-c9d9-4e95-a149-c008d43aaf14.png)

I don't know if this creates a security risk by using [safe](https://jinja.palletsprojects.com/en/3.1.x/templates/#working-with-automatic-escaping), but if it does I think you'd have to try and shoot yourself in the foot. I'm also not sure if docs of some kind should be added to point out that use can use HTML (carefully).