### PR TITLE
Hide "Contents" on pages with multiple TOC trees

### DIFF
--- a/src/furo/__init__.py
+++ b/src/furo/__init__.py
@@ -74,8 +74,8 @@ def has_not_enough_items_to_show_toc(
     except IndexError:
         val = True
     else:
-        # There's only the page's own toctree in there.
-        val = len(self_toctree) == 1 and self_toctree[0].tagname == "toctree"
+        # There's only the page's own toctree(s) in there.
+        val = all(entry.tagname == "toctree" for entry in self_toctree)
     return val
 
 


### PR DESCRIPTION
If a document has more than one TOC tree directive and no other headings on the page, an empty "Contents" section is rendered in the sidebar. Adjusting the hide-toc logic to check if all entries in the TOC tree are all local TOC tree entries.