### PR TITLE
Remove unused `templates_path`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,6 @@ extensions = [
     "sphinx_design",
     "sphinx_inline_tabs",
 ]
-templates_path = ["_templates"]
 
 # -- Options for extlinks ----------------------------------------------------
 #


### PR DESCRIPTION
Variable `templates_path` seems to be unused, since there is no `docs/_templates` subdir in this repo. This PR removes, the variable from the `docs/conf.py` file.