### PR TITLE
docs/conf: update copyright year

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ sys.path.append(os.path.abspath("./kitchen-sink/demo_py"))
 #
 
 project = "furo"
-copyright = "2020, Pradyun Gedam"
+copyright = "2020-2023, Pradyun Gedam"
 author = "Pradyun Gedam"
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
It seems that the copyright in the footer was not updated since the project was created. This PR changes it to `2020-2023`.