### PR TITLE
Add missing class to Font Awesome examples

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,6 +145,6 @@ if FONT_AWESOME_TESTING:
             "name": "GitHub",
             "url": "https://github.com/pradyunsg/furo",
             "html": "",
-            "class": "fa-solid fa-github fa-2x",
+            "class": "fa-brands fa-solid fa-github fa-2x",
         },
     ]

--- a/docs/customisation/footer.md
+++ b/docs/customisation/footer.md
@@ -86,7 +86,7 @@ If you wish to use Font Awesome icons in the footer, it's a two step process.
               "name": "GitHub",
               "url": "https://github.com/pradyunsg/furo",
               "html": "",
-              "class": "fa-solid fa-github fa-2x",
+              "class": "fa-brands fa-solid fa-github fa-2x",
           },
       ],
   }


### PR DESCRIPTION
As reported in https://github.com/pradyunsg/furo/discussions/590, the example/test about using font-awesome is missing class `fa-brands`. This PR updates `docs/conf.py` and `docs/customisation/footer.md`.

Ref: https://github.com/pradyunsg/furo/discussions/400
