### PR TITLE
docs/customisation/edit-button: explain that html_show_sourcelink is ignored

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -147,3 +147,13 @@ if FONT_AWESOME_TESTING:
             "class": "fa-brands fa-solid fa-github fa-2x",
         },
     ]
+
+
+def setup(app):
+    # See https://github.com/sphinx-doc/sphinx/issues/5562#issuecomment-434296574
+    app.add_object_type(
+        "confval",
+        "confval",
+        objname="configuration value",
+        indextemplate="pair: %s; configuration value",
+    )

--- a/docs/customisation/edit-button.md
+++ b/docs/customisation/edit-button.md
@@ -45,3 +45,8 @@ If you're building documentation on Read the Docs using a github.com-hosted repo
 If you wish to disable this, use {ref}`top_of_page_button` and set it to `None`.
 
 [sphinx-html_theme_options]: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_theme_options
+
+## Source link
+
+Sphinx configuration option {confval}`sphinx:html_show_sourcelink` is ignored by this theme.
+The only supported link to the sources is through the edit button.


### PR DESCRIPTION
As explained in https://github.com/pradyunsg/furo/discussions/374, html_show_sourcelink is ignored since a year ago. However, it took be a while to find that. Particularly, searching the docs did not provide any result.

This PR adds an explanation to the docs, so that users searching `html_show_sourcelink` will get some result and can be aware of it.

In order to link to the sphinx docs through intersphinx, I had to add a custom object type. See https://github.com/sphinx-doc/sphinx/issues/5562#issuecomment-434296574.