### PR TITLE
Remove Python 3.8 constraint from Black pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,6 @@ repos:
     rev: 23.1.0
     hooks:
       - id: black
-        language_version: python3.8
 
   - repo: https://github.com/asottile/blacken-docs
     rev: 1.13.0


### PR DESCRIPTION
The [`language_version` option](https://pre-commit.com/#overriding-language-version) tells pre-commit to run the hook using that specific version.

The current setting of 3.8 messes me up on my M1 because Python 3.8 does not work very well on Apple Silicon. 

Generally, it should not be necessary to set this value. Black determines what Python version to target with its `--target-version` option, which defaults to  `the project metadata in pyproject.toml`. Further, Black will error if it's run with an incompatible Python version.