### PR TITLE
Allow inheriting Furo as a Sphinx theme

### DIFF
--- a/src/furo/__init__.py
+++ b/src/furo/__init__.py
@@ -167,10 +167,11 @@ def _html_page_context(
     templatename: str,
     context: Dict[str, Any],
     doctree: Any,
+    *,
+    validate_furo: bool = True,
 ) -> None:
-    if app.config.html_theme != "furo":
+    if validate_furo and app.config.html_theme != "furo":
         return
-
     assert isinstance(app.builder, StandaloneHTMLBuilder)
 
     if "css_files" in context:
@@ -218,8 +219,10 @@ def _html_page_context(
     }
 
 
-def _builder_inited(app: sphinx.application.Sphinx) -> None:
-    if app.config.html_theme != "furo":
+def _builder_inited(
+    app: sphinx.application.Sphinx, *, validate_furo: bool = True
+) -> None:
+    if validate_furo and app.config.html_theme != "furo":
         return
     if "furo" in app.config.extensions:
         raise Exception(


### PR DESCRIPTION
To inherit Furo, the new Sphinx theme needs to call the setup code from `furo/__init__.py`'s `setup`. See https://github.com/pradyunsg/furo/pull/648 for an example.

However, currently, these setup helper functions will not run if the theme is not set to Furo. (That's a good default behavior because it avoids Furo doing undesired things when you have Furo installed but aren't actually using it.)

So, this adds the argument `validate_furo: bool = True` to both `_html_page_context` and `_builder_inited`. That allows plugins to use `functools.partial` to set the argument to `False`, as done in https://github.com/pradyunsg/furo/pull/648.

The default behavior is unaffected because the default is set to `True`.