### PR TITLE
Fix broken link

### DIFF
--- a/docs/customisation/index.md
+++ b/docs/customisation/index.md
@@ -50,6 +50,8 @@ html_theme_options = {
 Typos in the `*_css_variables` dictionary are silently ignored, and do not raise any errors or warnings. Double check that your spellings and values are correct and valid.
 ```
 
+(sidebar_hide_name)=
+
 ### `sidebar_hide_name`
 
 Controls whether you see the project's name in the sidebar of the documentation. This is useful when you only want to show your documentation's logo in the sidebar. The default is `False`.

--- a/docs/customisation/logo.md
+++ b/docs/customisation/logo.md
@@ -32,7 +32,7 @@ This is different from how `html_logo` works, which copies the given filename in
 
 ## Related Information
 
-It is also possible to [hide the name of the project in the sidebar](customisation/index.md#sidebar_hide_name), which might be desirable if the logo contains the project name.
+It is also possible to [hide the name of the project in the sidebar](sidebar_hide_name), which might be desirable if the logo contains the project name.
 
 [sphinx-html_logo]: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_logo
 [sphinx-html_theme_options]: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_theme_options


### PR DESCRIPTION
The link `hide the name of the project in the sidebar` at the bottom of this page: https://pradyunsg.me/furo/customisation/logo/

is broken. It should point to: https://pradyunsg.me/furo/customisation/#sidebar-hide-name

Hopefully this PR fixes it (not sure, not super familiar with the markdown format for sphinx).