### PR TITLE
Add block to allow inserting content before `main`

### DIFF
--- a/src/furo/theme/furo/page.html
+++ b/src/furo/theme/furo/page.html
@@ -58,6 +58,7 @@
       {% endblock left_sidebar %}
     </div>
   </aside>
+  {% block supermain %}
   <div class="main">
     <div class="content">
       <div class="article-container">
@@ -205,5 +206,6 @@
       {% endblock right_sidebar %}
     </aside>
   </div>
+  {% endblock supermain %}
 </div>
 {%- endblock %}


### PR DESCRIPTION
When extending Furo using a template with `extends`, there's currently not a way to add content within the `page` but before or after `main`. An example would be a top navigation bar that sits above the rest of the content but not over the left-side navigation bar.

This change adds a block that allows this through a template like this:
```
{% extends "furo/page.html" %}

{% block supermain %}
  <div class="my-custom-content">
    <h1>Hello World</h1>
  </div>
  {{ super() }}
  <div class="my-custom-content-on-the-bottom">
    <h1>Goodbye World</h1>
  </div>
{% endblock supermain %}
```
If you don't use templates to extend Furo, or if your templates don't define the `supermain` block, this change has no effect.