### PR TITLE
Use the reference `HtmlFormatter` class defined on `PygmentsBridge`

### DIFF
--- a/src/furo/__init__.py
+++ b/src/furo/__init__.py
@@ -352,8 +352,8 @@ def get_pygments_stylesheet() -> str:
 
     There is no way to tell Sphinx how the theme handles dark mode; at this time.
     """
-    light_formatter = HtmlFormatter(style=_KNOWN_STYLES_IN_USE["light"])
-    dark_formatter = HtmlFormatter(style=_KNOWN_STYLES_IN_USE["dark"])
+    light_formatter = PygmentsBridge.html_formatter(style=_KNOWN_STYLES_IN_USE["light"])
+    dark_formatter = PygmentsBridge.html_formatter(style=_KNOWN_STYLES_IN_USE["dark"])
 
     lines: List[str] = []
 


### PR DESCRIPTION
This patch respect the `HtmlFormatter` class set on `PygmentsBridge`, instead of hard-coding it into Furo. That way Furo can use the same Pygments formatter as the whole Sphinx machinery.

For the context, I encountered this issue while trying to implement a way for Pygments to render ANSI codes in documentation.