### PR TITLE
Make current page section detection resilient to sticky elements above header

### DIFF
--- a/src/furo/assets/scripts/furo.js
+++ b/src/furo/assets/scripts/furo.js
@@ -140,8 +140,9 @@ function setupScrollSpy() {
     recursive: true,
     navClass: "scroll-current",
     offset: () => {
-      let rem = parseFloat(getComputedStyle(document.documentElement).fontSize);
-      return header.getBoundingClientRect().height + 0.5 * rem + 1;
+      const rem = parseFloat(getComputedStyle(document.documentElement).fontSize);
+      const headerRect = header.getBoundingClientRect();
+      return headerRect.top + headerRect.height + 0.5 * rem + 1;
     },
   });
 }


### PR DESCRIPTION
## Problem

In https://github.com/Qiskit/qiskit_sphinx_theme, we have to add a custom header to the top of the site, like this:

![Screenshot 2023-06-09 at 6 31 10 AM](https://github.com/pradyunsg/furo/assets/14852634/52b4afad-8db1-415c-86f0-7b676b5a92c7)

This naturally breaks the detection of what the current scroll section is in the page table of contents, as it does not account for elements above the header:

![](https://user-images.githubusercontent.com/14852634/244154910-6e160be2-74c0-49a4-a3fc-d4e857b1d28f.png)

## Solution

This is easily fixed by also including the `header.top` in the offset. 

In base Furo, `header.top` is 0, so this change has no impact. I suspected this PR might be necessary for setting up banners, but because banners are not sticky, `header.top` ends up going back to 0 even with a banner when scrolling down.

While it has no impact on base Furo, it makes customization of Furo much easier. It's particularly complicated to tweak the JS code because it's being built by Webpack.