### PR TITLE
Set overflow-wrap on headings to fix long words breaking the layout

### DIFF
--- a/src/furo/assets/styles/base/_typography.sass
+++ b/src/furo/assets/styles/base/_typography.sass
@@ -38,6 +38,8 @@ h6
   padding-left: 0.5rem
   padding-right: 0.5rem
 
+  overflow-wrap: break-word
+
   + p
     margin-top: 0
 


### PR DESCRIPTION
Before:

![Screenshot 2023-06-20 at 3 41 34 PM](https://github.com/pradyunsg/furo/assets/14852634/f527473c-670b-40bf-a1b0-367d215681b3)

After:

![Screenshot 2023-06-20 at 3 41 10 PM](https://github.com/pradyunsg/furo/assets/14852634/6c7c6145-ae8c-49b7-b56b-fa2dfa9eff47)

This is particularly a problem for generated API docs from `autodoc` since the headers can get quite long.