### PR TITLE
Use ``sphinx.errors.ConfigError``

### DIFF
--- a/src/furo/__init__.py
+++ b/src/furo/__init__.py
@@ -16,6 +16,7 @@ from pygments.style import Style
 from pygments.token import Text
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.environment.adapters.toctree import TocTree
+from sphinx.errors import ConfigError
 from sphinx.highlighting import PygmentsBridge
 from sphinx.transforms.post_transforms import SphinxPostTransform
 
@@ -182,7 +183,7 @@ def _html_page_context(
 
     if "css_files" in context:
         if "_static/styles/furo.css" not in [c.filename for c in context["css_files"]]:
-            raise Exception(
+            raise ConfigError(
                 "This documentation is not using `furo.css` as the stylesheet. "
                 "If you have set `html_style` in your conf.py file, remove it."
             )
@@ -227,14 +228,17 @@ def _html_page_context(
 
 def _builder_inited(app: sphinx.application.Sphinx) -> None:
     if "furo" in app.config.extensions:
-        raise Exception(
+        raise ConfigError(
             "Did you list 'furo' in the `extensions` in conf.py? "
             "If so, please remove it. Furo does not work with non-HTML builders "
             "and specifying it as an `html_theme` is sufficient."
         )
 
-    if not isinstance(app.builder, StandaloneHTMLBuilder):
-        raise Exception(
+    if not isinstance(app.builder, StandaloneHTMLBuilder) or app.builder.name not in {
+        "html",
+        "dirhtml",
+    }:
+        raise ConfigError(
             "Furo is being used as an extension in a non-HTML build. "
             "This should not happen."
         )


### PR DESCRIPTION
This provides a nicer error when failing, as ``ConfigError`` inherits from ``SphinxError``