### PR TITLE
Drop Python 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = "A clean customisable Sphinx documentation theme."
 dynamic = ["version"]
 readme = "README.md"
 
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
   "beautifulsoup4",
   "sphinx >= 6.0,<8.0",
@@ -34,11 +34,11 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Operating System :: OS Independent",
   "Topic :: Documentation",
   "Topic :: Software Development :: Documentation",


### PR DESCRIPTION
Python 3.7 is end of life [^1]

[^1]: https://devguide.python.org/versions/

A