### PR TITLE
Remove pointless assert

### DIFF
--- a/src/furo/__init__.py
+++ b/src/furo/__init__.py
@@ -246,7 +246,6 @@ def _builder_inited(app: sphinx.application.Sphinx) -> None:
     app.add_css_file("styles/furo-extensions.css", priority=600)
 
     builder = app.builder
-    assert builder, "what?"
     assert (
         builder.highlighter is not None
     ), "there should be a default style known to Sphinx"


### PR DESCRIPTION
``builder`` is already known to be an instance of ``StandaloneHTMLBuilder`` from the check on line 236.

A