### PR TITLE
fix regression in 3631ff: Add json to allowed build dirs

### DIFF
--- a/src/furo/__init__.py
+++ b/src/furo/__init__.py
@@ -234,6 +234,7 @@ def _builder_inited(app: sphinx.application.Sphinx) -> None:
     if not isinstance(app.builder, StandaloneHTMLBuilder) or app.builder.name not in {
         "html",
         "dirhtml",
+        "json",
     }:
         raise ConfigError(
             "Furo is being used as an extension in a non-HTML build. "


### PR DESCRIPTION
Unfortunately commit 3631ffc4ea2f241b89bbd9b6c9d76e52a4226c56 introduced a regression for me.

I'm building a json target instead of the usual html. This target however isn't allowed anymore. Please re-add it.