### PR TITLE
fix as/are typo in blocks.rst

### DIFF
--- a/docs/kitchen-sink/blocks.rst
+++ b/docs/kitchen-sink/blocks.rst
@@ -90,7 +90,7 @@ Monospace Blocks
 ================
 
 Sphinx supports many kinds of monospace blocks. This section is meant to
-showcase *all* of them that as known to the author of this page, at the time of
+showcase *all* of them that are known to the author of this page, at the time of
 writing.
 
 Production List


### PR DESCRIPTION
Hi,

I think this is a typo, so thought I would open a PR to fix.

I found this since I often use different bits of Furo's docs as a reference for the different ways of doing things with Sphinx - thanks for writing them!