### PR TITLE
Update README.md to include both editions of Manim in the "Used By"

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ A ferret is actually a really good spirit animal for this project: cute, small, 
 - [pip] -- what I wrote this for
 - [Python Developer’s Guide][devguide]
 - [black]
+- [Manim Community Edition]
+- [Manim maintained by 3Blue1Brown]
 
 [urllib3]: https://urllib3.readthedocs.io/
 [attrs]: https://www.attrs.org/
@@ -96,6 +98,8 @@ A ferret is actually a really good spirit animal for this project: cute, small, 
 [psycopg3]: https://www.psycopg.org/psycopg3/docs/
 [black]: https://black.readthedocs.io/en/stable/
 [pelican]: https://docs.getpelican.com/en/latest/
+[Manim Community Edition]: https://docs.manim.community/en/stable/
+[Manim maintained by 3Blue1Brown]: https://3b1b.github.io/manim/
 
 <!-- end used-by -->
 


### PR DESCRIPTION
Manim is an Animation engine for explanatory math videos, and there are 2 editions of it maintained by the Mathematics YouTuber 3Blue1Brown with (https://github.com/3b1b/manim) and the community (https://github.com/ManimCommunity/manim/) respectively.

Both editions' documentation pages credit Furo in their footers (https://3b1b.github.io/manim/ and https://docs.manim.community/en/stable/) so I thought it would be a good idea to include both of these repositories' documentation pages in the "Used By" section of the README.md file so that Furo can be given credit since "mentioning who uses $thing is a good way to promote $thing". The repositories have 55k and 17k stars respectively, 3Blue1Brown has 5.6 Million YouTube subscribers, and Manim is amazing for producing animations, so it would be beneficial for Furo to have another popular project be reflected in the "Used By" section.

Screenshots:

https://3b1b.github.io/manim/:

![image](https://github.com/pradyunsg/furo/assets/134275562/e2b5cc21-dc00-4902-89e3-672049e5b899)

https://docs.manim.community/en/stable/:

![image](https://github.com/pradyunsg/furo/assets/134275562/55aefa4c-a453-4e4d-82fe-a1c21b0394b5)
