### PR TITLE
Add option to collapse navbar

### DIFF
--- a/docs/customisation/index.md
+++ b/docs/customisation/index.md
@@ -50,6 +50,18 @@ html_theme_options = {
 Typos in the `*_css_variables` dictionary are silently ignored, and do not raise any errors or warnings. Double check that your spellings and values are correct and valid.
 ```
 
+(collapse_navbar)=
+
+### `collapse_navbar`
+
+Whether to collapse the navbar, stopping the tree from being expanded. (False is default)
+
+```python
+html_theme_options = {
+    "collapse_navbar": True,
+}
+```
+
 (sidebar_hide_name)=
 
 ### `sidebar_hide_name`

--- a/src/furo/__init__.py
+++ b/src/furo/__init__.py
@@ -114,22 +114,6 @@ def get_colors_for_codeblocks(
     )
 
 
-def _compute_navigation_tree(context: Dict[str, Any]) -> str:
-    # The navigation tree, generated from the sphinx-provided ToC tree.
-    if "toctree" in context:
-        toctree = context["toctree"]
-        toctree_html = toctree(
-            collapse=False,
-            titles_only=True,
-            maxdepth=-1,
-            includehidden=True,
-        )
-    else:
-        toctree_html = ""
-
-    return get_navigation_tree(toctree_html)
-
-
 def _compute_hide_toc(
     context: Dict[str, Any],
     *,
@@ -224,7 +208,8 @@ def _html_page_context(
     context["furo_version"] = __version__
 
     # Values computed from page-level context.
-    context["furo_navigation_tree"] = _compute_navigation_tree(context)
+    context["toctree"] = context.get("toctree", None)
+    context["get_navigation_tree"] = get_navigation_tree
     context["furo_hide_toc"] = _compute_hide_toc(
         context, builder=cast(StandaloneHTMLBuilder, app.builder), docname=pagename
     )

--- a/src/furo/theme/furo/sidebar/navigation.html
+++ b/src/furo/theme/furo/sidebar/navigation.html
@@ -1,3 +1,8 @@
 <div class="sidebar-tree">
-  {{ furo_navigation_tree }}
+  {% if toctree is defined %}
+  {% set toctree_html = toctree(collapse=theme_collapse_navbar, titles_only=True, maxdepth=-1, includehidden=True) %}
+  {% else %}
+  {% set toctree_html = "" %}
+  {% endif %}
+  {{ get_navigation_tree(toctree_html) }}
 </div>

--- a/src/furo/theme/furo/theme.conf
+++ b/src/furo/theme/furo/theme.conf
@@ -15,6 +15,7 @@ sidebars =
 
 [options]
 announcement =
+collapse_navbar = False
 dark_css_variables =
 dark_logo =
 light_css_variables =


### PR DESCRIPTION
For large projects, the generation of non-collapsed navbar is frequently a reason for long build periods.

Motivated by the current option available in other themes, like sphinx-book-theme, this patch includes the 'collapse_navbar' option to the theme configuration.