### PR TITLE
Add Glasgow Interface Explorer to "Used By"

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ A ferret is actually a really good spirit animal for this project: cute, small, 
 - [pip] -- what I wrote this for
 - [Python Developer’s Guide][devguide]
 - [black]
+- [Glasgow Interface Explorer][glasgow]
 
 [urllib3]: https://urllib3.readthedocs.io/
 [attrs]: https://www.attrs.org/
@@ -96,6 +97,7 @@ A ferret is actually a really good spirit animal for this project: cute, small, 
 [psycopg3]: https://www.psycopg.org/psycopg3/docs/
 [black]: https://black.readthedocs.io/en/stable/
 [pelican]: https://docs.getpelican.com/en/latest/
+[glasgow]: https://glasgow-embedded.org/
 
 <!-- end used-by -->
 


### PR DESCRIPTION
I really like how Furo looks on the Glasgow Interface Explorer docs, and I think the way we integrated photos is a great way to showcase dark/light color schemes. Feel free to close this PR though if it's not wanted.