### PR TITLE
Patch ``app.config`` in a more resilient manner

### DIFF
--- a/src/furo/__init__.py
+++ b/src/furo/__init__.py
@@ -289,7 +289,7 @@ def _builder_inited(app: sphinx.application.Sphinx) -> None:
             pass  # Sphinx's config has changed.
         else:
             if key not in conf_py_settings:
-                app.config.__dict__[key] = new_default
+                app.config._raw_config.setdefault(key, new_default)
 
     # Change the default permalinks icon
     _update_default("html_permalinks_icon", new_default="#")

--- a/src/furo/__init__.py
+++ b/src/furo/__init__.py
@@ -283,7 +283,13 @@ def _builder_inited(app: sphinx.application.Sphinx) -> None:
     update_known_styles_state(app)
 
     def _update_default(key: str, *, new_default: Any) -> None:
-        app.config.values[key] = (new_default, *app.config.values[key][1:])
+        try:
+            conf_py_settings = app.config._raw_config
+        except AttributeError:
+            pass  # Sphinx's config has changed.
+        else:
+            if key not in conf_py_settings:
+                app.config.__dict__[key] = new_default
 
     # Change the default permalinks icon
     _update_default("html_permalinks_icon", new_default="#")


### PR DESCRIPTION
I had to add a workaround to ``_update_default`` in Sphinx 7.3.2.

There's no officially-supported method to change the default, but I believe the method here will work on pre and post Sphinx 7.3 -- in effect, if the user has not overriden the default via either ``conf.py`` or command-line overrides, set the new default value.

A