### PR TITLE
Indent all children of aside.footnote

### DIFF
--- a/src/furo/assets/styles/content/_footnotes.sass
+++ b/src/furo/assets/styles/content/_footnotes.sass
@@ -40,6 +40,6 @@ div.citation > span
   font-weight: 500
   padding-right: 0.25rem
 
-aside.footnote > p,
+aside.footnote > *:not(span),
 div.citation > p
   margin-left: 2rem


### PR DESCRIPTION
Previously, only p elements were indented, leaving things like code blocks and block quotes unindented.

Fixes https://github.com/pradyunsg/furo/discussions/729