### PR TITLE
Move a 'type: ignore' comment, for mypy

### DIFF
--- a/src/furo/__init__.py
+++ b/src/furo/__init__.py
@@ -308,8 +308,8 @@ def update_known_styles_state(app: sphinx.application.Sphinx) -> None:
 def _get_light_style(app: sphinx.application.Sphinx) -> Style:
     # fmt: off
     # For https://github.com/psf/black/issues/3869
-    return (
-        app  # type: ignore[no-any-return]
+    return (  # type: ignore[no-any-return]
+        app
             .builder
             .highlighter # type: ignore[attr-defined]
             .formatter_args["style"]


### PR DESCRIPTION
Trying to run `nox -s lint` on the project, I discovered that `mypy` doesn't like one particular `return` call because the `type: ignore` comment is on the wrong line.

#### Output before change

```text
src/furo/__init__.py:311: error: Returning Any from function declared to return "Style"  [no-any-return]
src/furo/__init__.py:312: error: Unused "type: ignore" comment  [unused-ignore]
```
