### PR TITLE
Section permalinks: fix hover styling

### DIFF
--- a/src/furo/__init__.py
+++ b/src/furo/__init__.py
@@ -308,8 +308,8 @@ def update_known_styles_state(app: sphinx.application.Sphinx) -> None:
 def _get_light_style(app: sphinx.application.Sphinx) -> Style:
     # fmt: off
     # For https://github.com/psf/black/issues/3869
-    return (
-        app  # type: ignore[no-any-return]
+    return (  # type: ignore[no-any-return]
+        app
             .builder
             .highlighter # type: ignore[attr-defined]
             .formatter_args["style"]

--- a/src/furo/assets/styles/content/_target.sass
+++ b/src/furo/assets/styles/content/_target.sass
@@ -13,6 +13,14 @@
 .headerlink
   font-weight: 100
   user-select: none
+  text-decoration-line: none
+  &:hover
+    color: var(--color-permalink-hover)
+
+.headerlink:visited
+  color: var(--color-permalink--visited)
+  &:hover
+    color: var(--color-permalink--visited-hover)
 
 h1,
 h2,

--- a/src/furo/assets/styles/variables/_colors.scss
+++ b/src/furo/assets/styles/variables/_colors.scss
@@ -29,6 +29,7 @@
   // Brand colors
   --color-brand-primary: #0a4bff;
   --color-brand-content: #2757dd;
+  --color-brand-highlight: #4f76e3;
   --color-brand-visited: #872ee0;
 
   // API documentation
@@ -139,6 +140,10 @@
   --color-link-underline--visited: var(--color-background-border);
   --color-link--visited--hover: var(--color-brand-visited);
   --color-link-underline--visited--hover: var(--color-foreground-border);
+
+  --color-permalink-hover: var(--color-brand-highlight);
+  --color-permalink--visited: var(--color-brand-content);
+  --color-permalink--visited-hover: var(--color-brand-highlight);
 }
 
 @mixin colors-dark {
@@ -164,6 +169,7 @@
   // Brand colors
   --color-brand-primary: #3d94ff;
   --color-brand-content: #5ca5ff;
+  --color-brand-highlight: #99c7ff;
   --color-brand-visited: #b27aeb;
 
   // Highlighted text (search)


### PR DESCRIPTION
- Remove `text-decoration` from the permalink icons, because it's barely visible and looks odd.
- To ensure they still have some hover-responsiveness, define a new brand color (`--color-brand-highlight`) — which in the default themes is simply `--color-brand-content` with the `L` value dialed up a bunch in the HSL colorspace — and set it as the permalink hover color.
- Also override visited-link coloring from permalinks, as a special case, and have them always use the brand-content / brand-highlight color.

#### Additional info

This was inspired by the fact that every time I hover over a section title, the section link icon appears, accompanied by a tiny dot in the lower-left corner that gets marginally more visible when the icon is hovered over. It took me forever to figure out that it even _**was**_ the tiny bit of the text-decoration-line that's actually visible around the icon's descender. But once I did work that out, it seemed really pointless for it to be there, doing nothing useful.

Adding an additional brand color is a _big_ flex just for this tiny feature, I realize. Alternatives would be to have the permalink icon hover to the text color, or to reverse that and have it initially appear text-colored, but hover to link color. I didn't try either of those, but they're options if adding the "special" highlight color seems too drastic.

Regarding the visited-link override: I normally _hate_ when sites disable visited-link coloring, and will typically userstyle it back in with extreme prejudice. But I didn't want to have to define a _second_ highlight color for the permalink hovers when they're also visited links, and permalinks are enough of a special case that I think not having them turn purple when used seems valid.