### PR TITLE
Change "Back to top" button background to secondary

### DIFF
--- a/src/furo/assets/styles/_scaffold.sass
+++ b/src/furo/assets/styles/_scaffold.sass
@@ -317,7 +317,7 @@ article
   border-radius: 1rem
   font-size: 0.8125rem
 
-  background: var(--color-background-primary)
+  background: var(--color-background-secondary)
   box-shadow: 0 0.2rem 0.5rem rgba(0, 0, 0, 0.05), #6b728080 0px 0px 1px 0px
 
   z-index: 10


### PR DESCRIPTION
Currently, it has the same background as the page content and is thus difficult to see. 

I propose to change the background to `--color-background-secondary` so that it stands out a little more. Also, that color variable is described as "// for navigation + ToC", so seems appropriate for "Back to top" navigation.

before / after:
![grafik](https://github.com/user-attachments/assets/943e72da-fedf-4cae-8e14-5875541abb17)      ![grafik](https://github.com/user-attachments/assets/d2c14fe2-fc81-40b8-a095-0de372ed8019)
