### PR TITLE
Remove "debug printf" for headerTop value

### DIFF
--- a/src/furo/assets/scripts/furo.js
+++ b/src/furo/assets/scripts/furo.js
@@ -11,7 +11,6 @@ const GO_TO_TOP_OFFSET = 64;
 function scrollHandlerForHeader(positionY) {
   const headerTop = Math.floor(header.getBoundingClientRect().top);
 
-  console.log(`headerTop: ${headerTop}`);
   if (headerTop == 0 && positionY != headerTop) {
     header.classList.add("scrolled");
   } else {


### PR DESCRIPTION
Commit 38f17af endeavored to "Improve watcher for scroll issues", and appears to have succeeded in that goal.

But it also added a "debug printf"-style `console.log` call for the value of `headerTop`, whenever that watcher is run. Which means that Furo-powered sites all over the Internet are constantly spewing (almost exclusively) `headerTop: 0` onto the console, as users browse their pages.
