### PR TITLE
Pin sphinx-basic-ng to a real version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">=3.8"
 dependencies = [
   "beautifulsoup4",
   "sphinx >= 6.0,<9.0",
-  "sphinx-basic-ng >= 1.0.0.beta2",
+  "sphinx-basic-ng >= 1.0.0b2",
   "pygments >= 2.7",
 ]
 


### PR DESCRIPTION
The version number here does not correspond to a proper release on pypi and can cause some problems for some installations.

This was mistakenly changed in https://github.com/pradyunsg/furo/commit/2ce7e89cb799bcb1312b711b17fca90d2979fa21
