### PR TITLE
page.html: Position the flyout to bottom-left, on ReadTheDocs

### DIFF
--- a/src/furo/theme/furo/page.html
+++ b/src/furo/theme/furo/page.html
@@ -212,6 +212,9 @@
             {%- endif %}
           </div>
         </div>
+        {%- if READTHEDOCS -%}
+          <readthedocs-flyout position="bottom-left"></readthedocs-flyout>
+        {%- endif -%}
         {% endblock footer %}
       </footer>
     </div>


### PR DESCRIPTION
As we know, ReadTheDocs has developed a new backend for their content integrations, including the floating menu of different versions and other links that's displayed when docs are built on the ReadTheDocs site. This new menu is built as an "addon" which can be configured in their system, but which can't be styled by theme CSS since it lives in a shadow DOM.

Recently (see readthedocs/addons#395), the ability to configure the position of that menu was added — the position defaults to the bottom-right of the page, but can be moved to any of bottom-left, top-right, or top-left. Positioning can be overridden in the project settings, but the new default setting for projects is "Default (from theme or Read the Docs)".

The Read the Docs default positioning is bottom-right, which in Furo docs tends to overlap content. The _theme_ default can be changed, however, by adding a new tag to the content body:

```html
<readthedocs-flyout position="{bottom,top}-{left,right}"></readthedocs-flyout>
```

This PR adds that tag to the `page.html` template, making the Furo default position for the flyout `bottom-left` instead of `bottom-right`. Again, individual projects can still override this in their settings; this merely sets the _default_ for the theme.

I don't know if this is the _best_ place to put such a tag, I only know that this worked for me in a test project. So consider this PR as more of a change _suggestion_ as a change _proposal_.  If there's a better implementation, I'm happy to make any changes necessary, or to close this entirely in favor of a better fix.
