### PR TITLE
Add rel=edit attribute to "Edit this page" link/icon

### DIFF
--- a/src/furo/theme/furo/components/edit-this-page.html
+++ b/src/furo/theme/furo/components/edit-this-page.html
@@ -3,7 +3,7 @@
 
 {%- macro furo_edit_button(url) -%}
 <div class="edit-this-page">
-  <a class="muted-link" href="{{ url }}" title="{{ _("Edit this page") }}">
+  <a class="muted-link" href="{{ url }}" rel="edit" title="{{ _("Edit this page") }}">
     <svg><use href="#svg-pencil"></use></svg>
     <span class="visually-hidden">{{ _("Edit this page") }}</span>
   </a>


### PR DESCRIPTION
This PR adds the rel="edit" attribute to the "Edit this page" edit link.

rel=edit lets a page indicate that the linked resource can be used to edit the page. It is defined at https://microformats.org/wiki/rel-edit. This can then be parsed by tools like the Universal Edit Button and custom bookmarklets to open the edit page corresponding with a website.