### PR TITLE
Fix flickering header drop shadow

### DIFF
--- a/src/furo/assets/scripts/furo.js
+++ b/src/furo/assets/scripts/furo.js
@@ -9,9 +9,7 @@ var lastScrollTop = document.documentElement.scrollTop;
 const GO_TO_TOP_OFFSET = 64;
 
 function scrollHandlerForHeader(positionY) {
-  const headerTop = Math.floor(header.getBoundingClientRect().top);
-
-  if (headerTop == 0 && positionY != headerTop) {
+  if (positionY > 0) {
     header.classList.add("scrolled");
   } else {
     header.classList.remove("scrolled");


### PR DESCRIPTION
On iOS Safari, headerTop can sometimes be negative when scrolling and the comparison to 0 is no longer true, which removes the drop shadow and causes the flickering.

Remove the comparison with the header position to avoid DOM layout reads and fix the flickering by not comparing to exactly 0.

The flickering issue was discussed in #415. This was then linked to #681, but I couldn't reproduce the issue with the "Back to Top" button.