### PR TITLE
Add `rel=nofollow` to github theme link

### DIFF
--- a/src/furo/theme/furo/page.html
+++ b/src/furo/theme/furo/page.html
@@ -171,7 +171,7 @@
             <a class="muted-link" href="https://pradyunsg.me">@pradyunsg</a>'s
             {% endif -%}
             {% trans %}
-            <a href="https://github.com/pradyunsg/furo">Furo</a>
+            <a href="https://github.com/pradyunsg/furo" rel="nofollow">Furo</a>
             {% endtrans %}
             {%- if last_updated -%}
             <div class="last-updated">


### PR DESCRIPTION
Happy user of the theme, and also happy to link to the sources, but would like to get rid of the "sink" on every page. Hope that's OK, otherwise feel free to close and I'll apply it only locally.