### PR TITLE
_scaffold.sass: remove old scrollbar selectors

### DIFF
--- a/src/furo/assets/styles/_scaffold.sass
+++ b/src/furo/assets/styles/_scaffold.sass
@@ -24,17 +24,8 @@ html
   scroll-behavior: smooth
 
 .sidebar-scroll, .toc-scroll, article[role=main] *
-  // Override Firefox scrollbar style
   scrollbar-width: thin
   scrollbar-color: var(--color-foreground-border) transparent
-
-  // Override Chrome scrollbar styles
-  &::-webkit-scrollbar
-    width: 0.25rem
-    height: 0.25rem
-  &::-webkit-scrollbar-thumb
-    background-color: var(--color-foreground-border)
-    border-radius: 0.125rem
 
 //
 // Overalls


### PR DESCRIPTION
The `::-webkit-scrollbar` selectors lead to 10k+ selector match attempts on browsers where they are redundant. Since these fallback rules were added 5 years ago, they are likely redundant by now.

The existing `article[role=main] *` performs much better and is all that's needed for modern browsers.