### PR TITLE
_code.sass: use :has selector for .highlight's parent div

### DIFF
--- a/src/furo/assets/styles/content/_code.sass
+++ b/src/furo/assets/styles/content/_code.sass
@@ -21,8 +21,7 @@ $code-spacing-vertical: 0.625rem
 $code-spacing-horizontal: 0.875rem
 
 // Wraps every literal block + line numbers.
-div[class*=" highlight-"],
-div[class^="highlight-"]
+div:has(>div.highlight)
   margin: 1em 0
   display: flex
 


### PR DESCRIPTION
The current selectors `div[class*=" highlight-"]` and `div[class^=highlight-]` are slow on larger pages with generated API docs. Use the more modern `:has(...)` to speed it up.

In one example it goes from 160'018 match attempts to just 280 match attempts, to ultimately apply to just 66 elements.

The selector is not exactly equivalent because it's not testing whether the parent has a `highlight-*` class, but I think we can always expect a combination `<div class="highlight-foo"><div class="highlight">...</div></div>` when using Sphinx.