### PR TITLE
Add Blender to "used by" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ A ferret is actually a really good spirit animal for this project: cute, small, 
 - [attrs] -- one of the early adopters!
 - [pip] -- what I wrote this for
 - [Python Developer’s Guide][devguide]
+- [Blender][blender] -- the popular 3D suite
 - [black]
 
 [urllib3]: https://urllib3.readthedocs.io/
@@ -95,6 +96,7 @@ A ferret is actually a really good spirit animal for this project: cute, small, 
 [pip]: https://pip.pypa.io/
 [psycopg3]: https://www.psycopg.org/psycopg3/docs/
 [black]: https://black.readthedocs.io/en/stable/
+[blender]: https://docs.blender.org/manual/en/latest/index.html
 [pelican]: https://docs.getpelican.com/en/latest/
 
 <!-- end used-by -->


### PR DESCRIPTION
I just noticed that Blender also uses furo for their documentation and thought it might be a nice candidate to add to the "used by" section since the software is very popular and highly regarded in the OSS community.