### PR TITLE
Correct GitHub URL of dep in gumshoe-patched.js

### DIFF
--- a/src/furo/assets/scripts/gumshoe-patched.js
+++ b/src/furo/assets/scripts/gumshoe-patched.js
@@ -3,7 +3,7 @@
  * A simple, framework-agnostic scrollspy script.
  * (c) 2019 Chris Ferdinandi
  * MIT License
- * httpx://github.com/cferdinandi/gumshoe
+ * https://github.com/cferdinandi/gumshoe
  */
 
 (function (root, factory) {


### PR DESCRIPTION
Over in `msgspec` we're starting to [enforce](https://github.com/jcrist/msgspec/pull/897) the use of only HTTPS links in docs and this gets pulled in:

<img width="1177" height="246" alt="image" src="https://github.com/user-attachments/assets/a58dffb7-490e-4940-836a-45350052629a" />

The library appears to be unmaintained but I opened a [PR](https://github.com/cferdinandi/gumshoe/pull/143) there anyway.

For now, we're explicitly ignoring that single URL.