### PR TITLE
Style semantic markup roles

### DIFF
--- a/docs/kitchen-sink/generic.rst
+++ b/docs/kitchen-sink/generic.rst
@@ -70,6 +70,29 @@ useful way is ``menuselection`` to show menus:
 For example, ``menuselection`` should break when it is too long to fit on a
 single line.
 
+Semantic roles
+^^^^^^^^^^^^^^
+
+Sphinx provides semantic markup roles that convey meaning beyond plain bold,
+italic, or inline code. Each group below has a distinct visual style.
+
+**CLI commands and build variables:**
+Use :command:`curl` or :program:`python3` to run commands. Build variables like
+:makevar:`CFLAGS` are also styled distinctly.
+
+**File paths, samples, and patterns:**
+Edit :file:`/etc/hosts` or :file:`conf.py`. A sample like :samp:`print({name})`
+uses replaceable parts. Regular expressions: :regexp:`^foo.*bar$`.
+
+**Environment variables and options:**
+Set :envvar:`PATH` or :envvar:`HOME` in your shell. Pass :option:`--verbose` or
+:option:`-O2` on the command line.
+
+**Reference metadata:**
+See :manpage:`grep(1)` or :manpage:`stdio(3)` for details. Content types like
+:mimetype:`text/plain` and :mimetype:`application/json`, mail headers like
+:mailheader:`Content-Type`, and newsgroups like :newsgroup:`comp.lang.python`.
+
 Long inline code wrapping
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/kitchen-sink/generic.rst
+++ b/docs/kitchen-sink/generic.rst
@@ -77,12 +77,13 @@ Sphinx provides semantic markup roles that convey meaning beyond plain bold,
 italic, or inline code. Each group below has a distinct visual style.
 
 **CLI commands and build variables:**
-Use :command:`curl` or :program:`python3` to run commands. Build variables like
+Use :command:`curl -sSL` or :program:`python3` to run commands. Build variables like
 :makevar:`CFLAGS` are also styled distinctly.
 
 **File paths, samples, and patterns:**
-Edit :file:`/etc/hosts` or :file:`conf.py`. A sample like :samp:`print({name})`
-uses replaceable parts. Regular expressions: :regexp:`^foo.*bar$`.
+Edit :file:`/etc/hosts`, :file:`conf.py`, or :file:`/usr/bin/python3.{x}`. A sample
+like :samp:`print({name})` uses replaceable parts. Regular expressions:
+:regexp:`^foo.*bar$`.
 
 **Environment variables and options:**
 Set :envvar:`PATH` or :envvar:`HOME` in your shell. Pass :option:`--verbose` or

--- a/src/furo/assets/styles/content/_index.sass
+++ b/src/furo/assets/styles/content/_index.sass
@@ -14,3 +14,4 @@
 @forward "tables"
 @forward "target"
 @forward "gui-labels"
+@forward "semantic-roles"

--- a/src/furo/assets/styles/content/_semantic-roles.sass
+++ b/src/furo/assets/styles/content/_semantic-roles.sass
@@ -1,0 +1,48 @@
+// Semantic roles
+//
+// Styling for Sphinx semantic markup roles that would otherwise be
+// indistinguishable from plain bold, italic, or inline code.
+// Reference: https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html
+
+// CLI commands and build variables
+// :command:, :program:, :makevar:
+strong.command,
+strong.program,
+strong.makevar
+  background-color: var(--color-cli-background)
+  border: 1px solid var(--color-cli-border)
+  padding: 0.1em 0.3em
+  border-radius: 0.2em
+  font-size: 0.9em
+  font-family: var(--font-stack--monospace)
+
+// File paths, samples, and patterns
+// :file:, :samp:, :regexp:
+code.file,
+code.samp,
+code.regexp
+  background: var(--color-path-background)
+
+  p &
+    border-color: var(--color-path-border)
+
+// Environment variables and options (cross-references)
+// :envvar:, :option:
+code.std-envvar,
+code.std-option
+  background: var(--color-envvar-background)
+
+  p &
+    border-color: var(--color-envvar-border)
+
+// Reference metadata
+// :manpage:, :mimetype:, :mailheader:, :newsgroup:
+em.manpage,
+em.mimetype,
+em.mailheader,
+em.newsgroup
+  background-color: var(--color-metadata-background)
+  border: 1px solid var(--color-metadata-border)
+  padding: 0.1em 0.3em
+  border-radius: 0.2em
+  font-size: 0.9em

--- a/src/furo/assets/styles/variables/_colors.scss
+++ b/src/furo/assets/styles/variables/_colors.scss
@@ -64,20 +64,20 @@
   --color-guilabel-text: var(--color-foreground-primary);
 
   // Semantic roles - CLI/Commands
-  --color-cli-background: #f0f7ee80;
-  --color-cli-border: #c1dbb980;
+  --color-cli-background: #f0f7eec0;
+  --color-cli-border: #c1dbb9c0;
 
   // Semantic roles - Paths/Patterns
-  --color-path-background: #fef8ee80;
-  --color-path-border: #f0deb480;
+  --color-path-background: #fef8eec0;
+  --color-path-border: #f0deb4c0;
 
   // Semantic roles - Environment/Options
-  --color-envvar-background: #f0eeff80;
-  --color-envvar-border: #c7c0f080;
+  --color-envvar-background: #f0eeffc0;
+  --color-envvar-border: #c7c0f0c0;
 
   // Semantic roles - Metadata
-  --color-metadata-background: #f0f0f080;
-  --color-metadata-border: #d5d5d580;
+  --color-metadata-background: #f0f0f0c0;
+  --color-metadata-border: #d5d5d5c0;
 
   // Admonitions!
   --color-admonition-background: transparent;

--- a/src/furo/assets/styles/variables/_colors.scss
+++ b/src/furo/assets/styles/variables/_colors.scss
@@ -63,6 +63,22 @@
   --color-guilabel-border: #bedaf580;
   --color-guilabel-text: var(--color-foreground-primary);
 
+  // Semantic roles - CLI/Commands
+  --color-cli-background: #f0f7ee80;
+  --color-cli-border: #c1dbb980;
+
+  // Semantic roles - Paths/Patterns
+  --color-path-background: #fef8ee80;
+  --color-path-border: #f0deb480;
+
+  // Semantic roles - Environment/Options
+  --color-envvar-background: #f0eeff80;
+  --color-envvar-border: #c7c0f080;
+
+  // Semantic roles - Metadata
+  --color-metadata-background: #f0f0f080;
+  --color-metadata-border: #d5d5d580;
+
   // Admonitions!
   --color-admonition-background: transparent;
 
@@ -172,6 +188,22 @@
   // GUI Labels
   --color-guilabel-background: #08356380;
   --color-guilabel-border: #13395f80;
+
+  // Semantic roles - CLI/Commands
+  --color-cli-background: #1a2e1a80;
+  --color-cli-border: #2d4a2d80;
+
+  // Semantic roles - Paths/Patterns
+  --color-path-background: #2e2a1a80;
+  --color-path-border: #4a402080;
+
+  // Semantic roles - Environment/Options
+  --color-envvar-background: #1f1a2e80;
+  --color-envvar-border: #342d4a80;
+
+  // Semantic roles - Metadata
+  --color-metadata-background: #1e1e2080;
+  --color-metadata-border: #3a3a3e80;
 
   // API documentation
   --color-api-keyword: var(--color-foreground-secondary);


### PR DESCRIPTION
## Summary

Adds visual styling for Sphinx semantic roles that are currently indistinguishable from plain bold, italic, or inline code. Addresses #890.

Roles are grouped into four visual categories, each with a subtle tinted background that works in both light and dark mode:

| Group | Roles | Visual treatment |
|-------|-------|------------------|
| CLI/Commands (green tint) | `:command:`, `:program:`, `:makevar:` | Monospace + pill background |
| Paths/Patterns (amber tint) | `:file:`, `:samp:`, `:regexp:` | Tinted code background |
| Environment/Options (purple tint) | `:envvar:`, `:option:` | Tinted code background |
| Metadata (grey tint) | `:manpage:`, `:mimetype:`, `:mailheader:`, `:newsgroup:` | Pill background |

### Files changed

- `src/furo/assets/styles/variables/_colors.scss` -- CSS custom properties (light + dark)
- `src/furo/assets/styles/content/_semantic-roles.sass` -- new stylesheet
- `src/furo/assets/styles/content/_index.sass` -- register the new module
- `docs/kitchen-sink/generic.rst` -- demo section with examples of all roles

### Note

This is a first pass at the styling. I'm very open to feedback on the colour choices, groupings, or overall approach -- if anything should be tweaked or done differently, please let me know and I'll update accordingly.

## Test plan

- [ ] Build docs and verify all roles in the kitchen-sink "Semantic roles" section render with distinct styling
- [ ] Toggle dark mode and confirm colours work in both themes
- [ ] Verify existing `:guilabel:`, `:kbd:`, `:menuselection:` styles are unaffected