### PR TITLE
Fix icons height in container, and thus fix their center alignement within the container

### DIFF
--- a/src/furo/assets/styles/_scaffold.sass
+++ b/src/furo/assets/styles/_scaffold.sass
@@ -229,10 +229,14 @@ article
 .content-icon-container
   float: right
   display: flex
+  align-items: center
   margin-top: 1.5rem
   margin-left: 1rem
   margin-bottom: 1rem
   gap: 0.5rem
+
+  & *
+    display: inline-flex
 
   .edit-this-page, .view-this-page
     svg


### PR DESCRIPTION
There seems to be a problem with icons alignemnt in many documentations using the theme. For example in [urllib3 documentation](https://urllib3.readthedocs.io/en/stable/) we have like this for example _(do check this out in the browser):_
<img width="91" height="28" alt="image" src="https://github.com/user-attachments/assets/150e2230-c05c-4d37-a94d-3936e99b99d8" />
and for accute eyes it's obvious that the icons are not well aligned to the center, though after adding `align-items: center` _(using for example in my case chrome devtools)_ we get this:
<img width="85" height="29" alt="image" src="https://github.com/user-attachments/assets/87c7c1da-0440-4244-b3d1-fa19631a3327" />
still not aligned yet, though after inspection that's because the intermediary html tags sitting between the svgs and the `.content-icon-container` get slightly different increasing heights at each level _(do check this out with the devtools)_, so for example in our case here for the **eye svg**, its height is different from its parent `<a> tag` which is even more different from the parent `div.view-this-page`, but adding this rule fixes this problem entirely
```
.content-icon-container * {
  display: inline-flex;
}
```
as this makes sure that all intermediary nested html sitting between the svgs and the `.content-icon-container` don't change height values

Now after adding this rule we finally get good alignement _(you'll notice the icon shifting after adding rule in devtools)_
<img width="79" height="25" alt="image" src="https://github.com/user-attachments/assets/689c8b18-9cc4-4849-9683-0cf74e430972" />

This fix will make sure that no weird alignement behaviors happen with the icons, like in this case with [qt for python documentation](https://doc.qt.io/qtforpython-6/)


