### PR TITLE
Add css variable for table header text color

### DIFF
--- a/src/furo/assets/styles/content/_tables.sass
+++ b/src/furo/assets/styles/content/_tables.sass
@@ -14,6 +14,7 @@ table.docutils
 
   th
     background: var(--color-table-header-background)
+    color: var(--color-table-header-text)
 
   td,
   th

--- a/src/furo/assets/styles/variables/_colors.scss
+++ b/src/furo/assets/styles/variables/_colors.scss
@@ -75,6 +75,7 @@
 
   // Tables
   --color-table-header-background: var(--color-background-secondary);
+  --color-table-header-text: var(--color-foreground-primary);
   --color-table-border: var(--color-background-border);
 
   // Cards


### PR DESCRIPTION
This pull request adds a CSS variable for the table header text color.

Previously, the header text color was not explicitly defined in `src/furo/assets/styles/content/_tables.sass`,
making it difficult to customize. This change introduces a CSS variable to allow easier styling.

## Related Issue

- #818