### PR TITLE
Create a shadow DOM tree for faster (10x) navtree generation

### DIFF
--- a/src/furo/__init__.py
+++ b/src/furo/__init__.py
@@ -16,16 +16,18 @@ from pygments.style import Style
 from pygments.token import Text
 from sphinx.builders.dirhtml import DirectoryHTMLBuilder
 from sphinx.builders.html import StandaloneHTMLBuilder
-from sphinx.environment.adapters.toctree import TocTree
+from sphinx.environment.adapters.toctree import TocTree, global_toctree_for_doc
 from sphinx.errors import ConfigError
 from sphinx.highlighting import PygmentsBridge
 from sphinx.transforms.post_transforms import SphinxPostTransform
 
-from .navigation import get_navigation_tree
+from .navigation import _NavigationTree, get_navigation_tree
 
 THEME_PATH = (Path(__file__).parent / "theme" / "furo").resolve()
 
 logger = logging.getLogger(__name__)
+
+_NAVIGATION_TREE_DOCNAME = "__furo_navigation_tree__"
 
 # GLOBAL STATE
 _KNOWN_STYLES_IN_USE: Dict[str, Optional[Style]] = {
@@ -114,20 +116,94 @@ def get_colors_for_codeblocks(
     )
 
 
-def _compute_navigation_tree(context: Dict[str, Any]) -> str:
-    # The navigation tree, generated from the sphinx-provided ToC tree.
-    if "toctree" in context:
-        toctree = context["toctree"]
-        toctree_html = toctree(
-            collapse=False,
-            titles_only=True,
-            maxdepth=-1,
-            includehidden=True,
-        )
-    else:
-        toctree_html = ""
+class _NavigationTreeBuilder:
+    """A small builder adapter used to build one canonical navigation tree.
 
-    return get_navigation_tree(toctree_html)
+    Sphinx asks the active HTML builder for relative links while resolving a
+    toctree.  If those links are computed for a real page, the generated HTML is
+    tied to that page and cannot be shared with the next page.  This adapter
+    gives ``global_toctree_for_doc`` just the builder surface it needs: the
+    shared tag set and a ``get_relative_uri`` implementation.
+
+    Instead of returning page-relative paths, ``get_relative_uri`` returns stable
+    placeholder tokens and records the docname each token represents.  The
+    placeholders make the canonical HTML independent of any one page.  The
+    compiled navigation tree later turns those tokens back into real relative
+    links for each page that is being written.
+    """
+
+    def __init__(self, builder: StandaloneHTMLBuilder) -> None:
+        self.tags = builder.tags
+        self.token_to_docname: Dict[str, str] = {}
+        self._docname_to_token: Dict[str, str] = {}
+
+    def get_relative_uri(self, _from: str, to: str) -> str:
+        try:
+            return self._docname_to_token[to]
+        except KeyError:
+            token = f"__furo_navigation_doc_{len(self._docname_to_token)}__"
+            self._docname_to_token[to] = token
+            self.token_to_docname[token] = to
+            return token
+
+
+def _get_cached_navigation_tree(builder: StandaloneHTMLBuilder) -> _NavigationTree:
+    """Return the per-builder cached Furo navigation tree.
+
+    The ``html-page-context`` event runs once for every standalone page that the
+    HTML builder writes.  Before this cache, Furo used that hook to call
+    ``context["toctree"]`` for every page.  For large projects that meant each
+    page recomputed Sphinx's global toctree, copied a large docutils tree, and
+    then parsed the resulting HTML with BeautifulSoup.
+
+    Furo asks Sphinx for the same structural tree on every page: no collapsing,
+    titles only, unlimited depth, and hidden toctrees included.  The only
+    page-specific parts are the relative ``href`` values and the state used to
+    mark the current page and open ancestors.  Cache that structural tree on the
+    shared ``StandaloneHTMLBuilder`` instance so all page writes in this builder
+    process reuse it.  Parallel Sphinx writes use separate builder processes, so
+    each process builds its own cache and no cross-build global state is needed.
+    """
+    cached = getattr(builder, "_furo_navigation_tree", None)
+    if isinstance(cached, _NavigationTree):
+        return cached
+
+    placeholder_builder = _NavigationTreeBuilder(builder)
+    # Use a sentinel docname that is not one of the project's documents.  That
+    # gives us a canonical tree with no real page marked current; current-page
+    # state is restored later by _NavigationTree.render().
+    toctree = global_toctree_for_doc(
+        builder.env,
+        _NAVIGATION_TREE_DOCNAME,
+        placeholder_builder,  # type: ignore[arg-type]
+        collapse=False,
+        titles_only=True,
+        maxdepth=-1,
+        includehidden=True,
+    )
+    toctree_html = builder.render_partial(toctree)["fragment"]
+    navigation_tree = _NavigationTree(
+        get_navigation_tree(toctree_html),
+        token_to_docname=placeholder_builder.token_to_docname,
+    )
+    setattr(builder, "_furo_navigation_tree", navigation_tree)
+    return navigation_tree
+
+
+def _compute_navigation_tree(
+    app: sphinx.application.Sphinx, context: Dict[str, Any], pagename: str
+) -> str:
+    # The navigation tree, generated from the sphinx-provided ToC tree.
+    if "toctree" not in context:
+        return ""
+
+    builder = cast(StandaloneHTMLBuilder, app.builder)
+    # Render the shared structural tree for this page by patching only the
+    # per-page HTML state: relative hrefs, current/current-page classes, and
+    # toctree checkbox expansion.
+    return _get_cached_navigation_tree(builder).render(
+        builder=builder, pagename=pagename
+    )
 
 
 def _compute_hide_toc(
@@ -224,7 +300,7 @@ def _html_page_context(
     context["furo_version"] = __version__
 
     # Values computed from page-level context.
-    context["furo_navigation_tree"] = _compute_navigation_tree(context)
+    context["furo_navigation_tree"] = _compute_navigation_tree(app, context, pagename)
     context["furo_hide_toc"] = _compute_hide_toc(
         context, builder=cast(StandaloneHTMLBuilder, app.builder), docname=pagename
     )

--- a/src/furo/navigation.py
+++ b/src/furo/navigation.py
@@ -1,8 +1,46 @@
-"""Generate the navigation tree from Sphinx's toctree function's output."""
+"""Generate and cache Furo's navigation tree.
+
+Furo starts from the HTML fragment produced by Sphinx's toctree machinery.
+``get_navigation_tree`` performs the traditional one-time Furo augmentation on
+that fragment: it adds the CSS-only collapse controls, marks entries that have
+children, and preserves the same current-page class behavior as the original
+BeautifulSoup-based implementation.
+
+``_NavigationTree`` is the cacheable second phase.  It compiles the augmented
+HTML into a much smaller tree of constants and ``_NavigationElement`` objects.
+That reduced tree is not a general-purpose DOM.  It retains only the information
+that changes between pages: link targets, ancestor membership for current-state
+classes, the list item representing each page, and the checkbox associated with
+each expandable branch.  Rendering a page then patches those pieces directly
+instead of asking Sphinx to resolve the global toctree and asking BeautifulSoup
+to parse the full navigation HTML again.
+"""
 
 import functools
+import html
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set, Tuple
 
-from bs4 import BeautifulSoup, Tag
+from bs4 import BeautifulSoup, Comment, NavigableString, Tag
+
+_VOID_ELEMENTS = frozenset(
+    {
+        "area",
+        "base",
+        "br",
+        "col",
+        "embed",
+        "hr",
+        "img",
+        "input",
+        "link",
+        "meta",
+        "param",
+        "source",
+        "track",
+        "wbr",
+    }
+)
 
 
 def _get_navigation_expand_image(soup: BeautifulSoup) -> Tag:
@@ -81,3 +119,302 @@ def get_navigation_tree(toctree_html: str) -> str:
         last_element_with_current["class"].append("current-page")
 
     return str(soup)
+
+
+def _as_class_list(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return value.split()
+    return [str(item) for item in value]
+
+
+def _stringify_attribute_value(value: Any) -> str:
+    if isinstance(value, list):
+        return " ".join(str(item) for item in value)
+    return str(value)
+
+
+def _add_current_class(classes: List[str], *, tag: str) -> None:
+    if "current" in classes:
+        return
+    if tag == "a":
+        classes.insert(0, "current")
+        return
+    try:
+        index = classes.index("has-children")
+    except ValueError:
+        classes.append("current")
+    else:
+        classes.insert(index, "current")
+
+
+def _find_target(
+    href: str, token_to_docname: Dict[str, str]
+) -> Tuple[Optional[str], str]:
+    for token, docname in token_to_docname.items():
+        if href == token:
+            return docname, ""
+        if href.startswith(token + "#"):
+            return docname, href[len(token) :]
+    return None, ""
+
+
+def _render_attributes(attrs: Dict[str, str]) -> str:
+    if not attrs:
+        return ""
+
+    rendered = []
+    for name in sorted(attrs):
+        value = attrs[name]
+        rendered.append(f'{name}="{html.escape(value, quote=True)}"')
+    return " " + " ".join(rendered)
+
+
+@dataclass
+class _NavigationElement:
+    """A reduced HTML element used to render cached navigation HTML.
+
+    Instances form a tree with string children for already-rendered text and
+    comments.  They intentionally model only the subset of HTML that Furo needs
+    to vary per page:
+
+    * ``target_docname`` and ``target_anchor`` describe an ``<a href>`` whose
+      canonical placeholder link must be replaced with a page-relative link.
+    * ``current_docnames`` is the set of pages contained by this element's
+      subtree; ``<li>`` and ``<ul>`` elements use it to regain the ``current``
+      class for the active branch.
+    * ``checkbox_docnames`` is set on Furo's ``<input class="toctree-checkbox">``
+      controls so the current branch can be expanded with ``checked=""``.
+    * ``current_page_index`` identifies the list item that should receive
+      ``current-page`` for a given docname.
+
+    The result is a partially parsed navigation tree: enough structure to patch
+    ``href``, ``class``, and ``checked`` attributes deterministically, without
+    carrying the cost and API surface of a full BeautifulSoup tree.
+    """
+
+    name: str
+    attrs: Dict[str, str]
+    children: List[Any]
+    target_docname: Optional[str] = None
+    target_anchor: str = ""
+    current_docnames: Set[str] = field(default_factory=set)
+    checkbox_docnames: Set[str] = field(default_factory=set)
+    current_page_index: Optional[int] = None
+
+    @property
+    def _is_current_page_link(self) -> bool:
+        return (
+            self.name == "a"
+            and self.target_docname is not None
+            and not self.target_anchor
+        )
+
+    def render(
+        self,
+        *,
+        builder: Any,
+        pagename: str,
+        current_page_index: Optional[int],
+    ) -> str:
+        attrs = dict(self.attrs)
+
+        # All per-page class updates happen on a copy of the cached attributes.
+        # The cached tree must remain canonical so the next page starts from the
+        # same state.
+        classes = _as_class_list(attrs.get("class"))
+
+        # Sphinx marks every ancestor of the current page with "current".  The
+        # cached tree was built with no page current, so restore that class from
+        # the precomputed subtree docname set.
+        if self.name in {"li", "ul"} and pagename in self.current_docnames:
+            _add_current_class(classes, tag=self.name)
+
+        # The <a> for the current document also carries "current".
+        if self._is_current_page_link and self.target_docname == pagename:
+            _add_current_class(classes, tag=self.name)
+
+        # Furo additionally marks exactly one <li> as "current-page".  The
+        # numeric index preserves BeautifulSoup-era behavior when a document is
+        # linked more than once: the last matching list item wins.
+        if (
+            self.name == "li"
+            and self.current_page_index is not None
+            and self.current_page_index == current_page_index
+        ):
+            classes.append("current-page")
+        if classes:
+            attrs["class"] = " ".join(classes)
+        else:
+            attrs.pop("class", None)
+
+        # Canonical links were captured as placeholder tokens so the tree could
+        # be shared by every page.  Resolve them through the real builder here,
+        # where the source page is known.  Sphinx renders a self-link as "", but
+        # the browser needs "#" in an href.
+        if self.target_docname is not None and "href" in attrs:
+            attrs["href"] = (
+                builder.get_relative_uri(pagename, self.target_docname)
+                + self.target_anchor
+            ) or "#"
+
+        # Furo's left navigation opens branches with checkbox state.  Recompute
+        # that state from the cached subtree membership instead of storing the
+        # checked attribute from whichever page happened to build the cache.
+        if self.name == "input" and "toctree-checkbox" in _as_class_list(
+            self.attrs.get("class")
+        ):
+            if pagename in self.checkbox_docnames:
+                attrs["checked"] = ""
+            else:
+                attrs.pop("checked", None)
+
+        attributes = _render_attributes(attrs)
+        if self.name in _VOID_ELEMENTS and not self.children:
+            return f"<{self.name}{attributes}/>"
+
+        rendered_children = "".join(
+            child.render(
+                builder=builder,
+                pagename=pagename,
+                current_page_index=current_page_index,
+            )
+            if isinstance(child, _NavigationElement)
+            else child
+            for child in self.children
+        )
+        return f"<{self.name}{attributes}>{rendered_children}</{self.name}>"
+
+
+class _NavigationTree:
+    """A cacheable representation of Furo's left navigation.
+
+    The input HTML is the canonical navigation fragment produced by Sphinx and
+    augmented by ``get_navigation_tree``.  During construction, it is converted
+    into a tree of strings and ``_NavigationElement`` objects.  Text and comment
+    nodes become pre-escaped strings.  Element nodes keep only the static
+    attributes plus the small amount of dynamic state required to render any
+    page:
+
+    * placeholder ``href`` tokens mapped back to docnames and anchors,
+    * descendant docname sets used to mark the current branch,
+    * branch docname sets used to check expandable navigation inputs, and
+    * the per-docname list-item index used for ``current-page``.
+
+    Rendering is therefore linear in the navigation HTML size and does not
+    invoke Sphinx's global toctree resolver or BeautifulSoup for each output
+    page.
+    """
+
+    def __init__(self, html: str, *, token_to_docname: Dict[str, str]) -> None:
+        self._current_page_indices: Dict[str, int] = {}
+        self._next_current_page_index = 0
+
+        soup = BeautifulSoup(html, "html.parser")
+        self._children = [
+            self._compile_node(child, token_to_docname) for child in soup.contents
+        ]
+
+    def _compile_node(self, node: Any, token_to_docname: Dict[str, str]) -> Any:
+        # Preserve comments and escape text nodes up front.  BeautifulSoup does
+        # this serialization work once here instead of once per output page.
+        if isinstance(node, Comment):
+            return f"<!--{node}-->"
+        if isinstance(node, NavigableString):
+            return html.escape(str(node), quote=False)
+        if not isinstance(node, Tag):
+            return ""
+
+        attrs = {
+            str(key): _stringify_attribute_value(value)
+            for key, value in node.attrs.items()
+        }
+
+        target_docname = None
+        target_anchor = ""
+        if node.name == "a" and "href" in attrs:
+            # Links in the canonical tree point at placeholder tokens generated
+            # by _NavigationTreeBuilder.  Record the real target once, then
+            # render page-relative hrefs later with the active Sphinx builder.
+            target_docname, target_anchor = _find_target(
+                attrs["href"], token_to_docname
+            )
+
+        children = [
+            self._compile_node(child, token_to_docname) for child in node.contents
+        ]
+
+        current_docnames: Set[str] = set()
+        if target_docname is not None and not target_anchor:
+            current_docnames.add(target_docname)
+        for child in children:
+            if isinstance(child, _NavigationElement):
+                current_docnames.update(child.current_docnames)
+
+        # A list item's own page is normally the first page-level link under the
+        # item, not necessarily the <li> itself.  Capturing this separately lets
+        # render() apply "current-page" to the same element that the original
+        # BeautifulSoup pass would have marked.
+        current_page_docname = target_docname
+        current_page_anchor = target_anchor
+        if node.name == "li":
+            for child in children:
+                if (
+                    isinstance(child, _NavigationElement)
+                    and child._is_current_page_link
+                ):
+                    current_page_docname = child.target_docname
+                    current_page_anchor = child.target_anchor
+                    break
+
+        current_page_index = None
+        if (
+            node.name == "li"
+            and current_page_docname is not None
+            and not current_page_anchor
+        ):
+            current_page_index = self._next_current_page_index
+            self._next_current_page_index += 1
+            # Match get_navigation_tree's "last element with current" behavior:
+            # if a docname appears multiple times, the later <li> receives
+            # "current-page".
+            self._current_page_indices[current_page_docname] = current_page_index
+
+        element = _NavigationElement(
+            name=node.name,
+            attrs=attrs,
+            children=children,
+            target_docname=target_docname,
+            target_anchor=target_anchor,
+            current_docnames=current_docnames,
+            current_page_index=current_page_index,
+        )
+
+        if node.name == "li":
+            # The checkbox Furo inserts for an expandable branch is a direct
+            # child of that branch's <li>.  Attach the branch's docname set to
+            # the checkbox so render() can add checked="" when the current page
+            # is anywhere under that branch.
+            for child in children:
+                if (
+                    isinstance(child, _NavigationElement)
+                    and child.name == "input"
+                    and "toctree-checkbox" in _as_class_list(child.attrs.get("class"))
+                ):
+                    child.checkbox_docnames = current_docnames
+
+        return element
+
+    def render(self, *, builder: Any, pagename: str) -> str:
+        current_page_index = self._current_page_indices.get(pagename)
+        return "".join(
+            child.render(
+                builder=builder,
+                pagename=pagename,
+                current_page_index=current_page_index,
+            )
+            if isinstance(child, _NavigationElement)
+            else child
+            for child in self._children
+        )

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,0 +1,80 @@
+"""Tests for Furo's sidebar navigation rendering."""
+
+from furo.navigation import _NavigationTree, get_navigation_tree
+
+
+class _FakeBuilder:
+    """Minimal HTML builder stub for relative links."""
+
+    def __init__(self, pagename):
+        self.pagename = pagename
+
+    def get_relative_uri(self, from_, to):
+        """Return the relative URI from the current page to a target docname."""
+        assert from_ == self.pagename
+        return {
+            ("guide/install", "intro"): "../intro.html",
+            ("guide/install", "guide"): "../guide.html",
+            ("guide/install", "guide/install"): "",
+            ("guide/install", "guide/usage"): "usage.html",
+            ("intro", "intro"): "",
+            ("intro", "guide"): "guide.html",
+            ("intro", "guide/install"): "guide/install.html",
+            ("intro", "guide/usage"): "guide/usage.html",
+        }[(from_, to)]
+
+
+_TOKEN_TO_DOCNAME = {
+    "__doc_0__": "intro",
+    "__doc_1__": "guide",
+    "__doc_2__": "guide/install",
+    "__doc_3__": "guide/usage",
+}
+
+
+_TOCTREE_TEMPLATE = """\
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="__doc_0__">Intro &amp; Setup <!-- omit in toc --></a></li>
+<li class="toctree-l1"><a class="reference internal" href="__doc_1__">Guide</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="__doc_2__">Install</a></li>
+<li class="toctree-l2"><a class="reference internal" href="__doc_3__">Usage</a></li>
+</ul></li>
+</ul>"""
+
+
+def _render_cached_navigation(pagename):
+    """Render the cached navigation tree for a page."""
+    tree = _NavigationTree(
+        get_navigation_tree(_TOCTREE_TEMPLATE), token_to_docname=_TOKEN_TO_DOCNAME
+    )
+    return tree.render(builder=_FakeBuilder(pagename), pagename=pagename)
+
+
+def test_navigation_tree_renders_current_leaf_like_sphinx_toctree():
+    """The cached tree renders a nested current leaf like the old code path."""
+    expected_toctree = """\
+<ul class="current">
+<li class="toctree-l1"><a class="reference internal" href="../intro.html">Intro &amp; Setup <!-- omit in toc --></a></li>
+<li class="toctree-l1 current"><a class="reference internal" href="../guide.html">Guide</a><ul class="current">
+<li class="toctree-l2 current"><a class="current reference internal" href="#">Install</a></li>
+<li class="toctree-l2"><a class="reference internal" href="usage.html">Usage</a></li>
+</ul></li>
+</ul>"""
+
+    assert _render_cached_navigation("guide/install") == get_navigation_tree(
+        expected_toctree
+    )
+
+
+def test_navigation_tree_renders_current_toplevel_like_sphinx_toctree():
+    """The cached tree renders a top-level current page like the old code path."""
+    expected_toctree = """\
+<ul class="current">
+<li class="toctree-l1 current"><a class="current reference internal" href="#">Intro &amp; Setup <!-- omit in toc --></a></li>
+<li class="toctree-l1"><a class="reference internal" href="guide.html">Guide</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="guide/install.html">Install</a></li>
+<li class="toctree-l2"><a class="reference internal" href="guide/usage.html">Usage</a></li>
+</ul></li>
+</ul>"""
+
+    assert _render_cached_navigation("intro") == get_navigation_tree(expected_toctree)


### PR DESCRIPTION
We attempted to deploy Furo for the [LLVM Sphinx docs](https://llvm.org/docs/), (llvm/llvm-project#184440), but our sphinx build and publish bot timed out. I replicated the timeout locally, and came up with this PR, which speeds up the build by 10x.

The slowdown occurred because LLVM has a very large global navigation tree. I've seen in the discussions that Furo is intended for "small sites", so perhaps our use case is out of scope, but I thought I'd share anyway.

The bottleneck for us was that each page would reparse the global navtree for every render with beautiful soup. This is kind of O(n^2), it's for each page, parse HTML which has at least as many elements as there are pages, and beautiful soup isn't super fast.

The solution in this PR was to build a sort of shadow DOM with the _NavigationTree and _NavigationElement classes. Rendering the final navtree for each page is a matter of walking this tree, replacing the HTML elements that vary (CSS class, href, etc), and concatenating the rest of the HTML which does not vary between pages.

My initial thought was to use a templating engine to substitute in the parts that vary without parsing HTML, but that ended up being slower.

I synthesized a project generation benchmark, with a hidden toctree containing N pages, and got these numbers before and after this change:

  N=100: 1.85s -> 0.94s
  N=200: 5.41s -> 1.45s
  N=400: 18.82s -> 2.96s
  N=800: 75.43s -> 7.83s

That is roughly a 10x speedup in project generation time for the large-navigation case. This change allowed me to finish LLVM's 1,233 page doc build in 1:27.47, instead of hitting my local 10min timeout.

The code is LLM-generated and the PR description is not. I'm happy to try to tune it up or reduce scope to make it fit better. I think the general idea of a custom tree of navigation elements does make sense. Thanks for the theme, and I appreciate any time you spend reviewing this PR. 🙏 