### PR TITLE
fix(a11y): make the sidebar expander keyboard operable

### DIFF
--- a/src/furo/assets/styles/components/_sidebar.sass
+++ b/src/furo/assets/styles/components/_sidebar.sass
@@ -194,9 +194,28 @@
     &:hover
       background: var(--color-sidebar-item-background--hover)
 
+// This checkbox holds the expanded/collapsed state, and the <label> above is the
+// visible affordance for it. It has to stay in the accessibility tree and in the
+// tab order: `display: none` removes it from both, which leaves the expander
+// operable with a pointer but not with a keyboard, and hides its accessible name
+// from assistive technology. Visually hidden is what was wanted here, not `none`.
 .toctree-checkbox
   position: absolute
-  display: none
+  width: 1px
+  height: 1px
+  padding: 0
+  margin: -1px
+  border: 0
+  overflow: hidden
+  clip: rect(0, 0, 0, 0)
+  clip-path: inset(50%)
+  white-space: nowrap
+
+  // The input has no painted box of its own, so its focus ring has to be drawn
+  // on the label that stands in for it.
+  &:focus-visible ~ label .icon
+    outline: 2px solid var(--color-foreground-primary)
+    outline-offset: -2px
 
 ////////////////////////////////////////////////////////////////////////////////
 // Togglable expand/collapse


### PR DESCRIPTION
Follow-up to discussion #933, where you said you would like to see what the disclosure navigation pattern would look like.

While reading the existing implementation to build that, I found something more basic, and I think it is worth fixing on its own before anything is redesigned. This PR is only that fix. It is CSS-only, involves no JavaScript, and does not change the expand and collapse mechanism.

## The problem

`navigation.py` already does the accessible thing. Every collapsible section gets a real `<input type="checkbox">` carrying `role="switch"` and an accessible name of `Toggle navigation of {section}`.

The stylesheet then set that checkbox to `display: none`.

`display: none` removes an element from the accessibility tree **and** from the tab order. So:

- the expander could only be operated by pointing at its `<label>` and clicking, and a `<label>` is not focusable, so there was no keyboard path to it at all
- the `role="switch"` and the `aria-label` never reached assistive technology; they were inert markup
- with a section collapsed, its child pages were not reachable from the sidebar without a mouse

That is a **WCAG 2.1.1 Keyboard failure, Level A**. Nothing was wrong with the semantics you already had. The stylesheet was discarding them.

I suspect the intent was "visually hidden" and `display: none` was just the shortest way to write it.

## The change

Swap `display: none` for the usual visually-hidden clip. The input paints nothing either way and layout is unchanged, but it now takes focus and is exposed to assistive technology.

Because the input has no painted box, its focus ring is drawn on the label that stands in for it, behind `:focus-visible` so it only appears for keyboard users.

The CSS-only mechanism is untouched: `:checked ~ ul` still does the work, `display: none` on a **sibling** selector never had anything to do with hiding the input itself, and the sidebar keeps working with JavaScript disabled.

## Verified

On a local `dirhtml` build of this repo's own docs, comparing before and after.

**Accessibility tree, before:** no expander present anywhere. The sidebar exposed only links.

**After:** four controls, each following its link.

```
link   "Customisation"
switch "Toggle navigation of Customisation"
link   "Markup Reference"
switch "Toggle navigation of Markup Reference"
...
```

Also checked, with real keyboard input rather than scripted focus:

- `Tab` reaches the expander, in a sensible order: the section link, then its expander
- `:focus-visible` matches and the indicator renders on the label, `outline: 2px solid`
- toggling expands the section, `display` goes `none` to `block`, and the 11 child links under Customisation become reachable
- the control keeps its 1 by 1 box, so nothing moves on the page

**Two things I did not verify, and would rather say so than imply otherwise:**

1. **Space activation specifically.** My automation harness delivered a keydown with an empty `key`, so the keystroke never actually arrived. Native checkbox activation is not really in doubt, but I did not exercise it, so I am not claiming it.
2. **A screen reader pass.** I said in #933 that I would confirm with NVDA or VoiceOver, and that has not happened yet. The accessibility tree evidence above is a tree dump, not a screen reader. I will follow up with a VoiceOver run and report back here.

## What this deliberately does not do

It does not implement the disclosure pattern from #933. I would rather land the Level A fix on its own and discuss the semantics separately, because that part is a genuine design question and it is yours to make.

The short version of where I got to: `aria-expanded` is the conventional signal for a disclosure, and MDN lists `checkbox` among the roles that support it. But `aria-expanded` is a static attribute, and **CSS cannot keep it in sync with `:checked`**. So a faithful disclosure pattern needs JavaScript to mirror the state, which is exactly the progressive enhancement you said you would be open to.

That leaves a real choice: keep `role="switch"`, which announces on and off and stays accurate with no JavaScript at all, or move to `aria-expanded` maintained by a few lines of JS, with the switch semantics as the no-JS fallback. There is a reasonable case for either and I did not want to pick one for you inside a bug fix. Happy to write the second version if you tell me which you prefer.
