### PR TITLE
logo: fix centering

### DIFF
--- a/src/furo/theme/furo/sidebar/brand.html
+++ b/src/furo/theme/furo/sidebar/brand.html
@@ -11,7 +11,7 @@ documentation page.
 Hope your day's going well. :)
 
 -#}
-<a class="sidebar-brand{% if logo %} centered{% endif %}" href="{{ pathto(master_doc) }}">
+<a class="sidebar-brand{% if logo_url %} centered{% endif %}" href="{{ pathto(master_doc) }}">
   {%- block brand_content %}
   {#- Remember to update the prefetch logic in `block logo_prefetch_links` in base.html #}
   {%- if logo_url %}


### PR DESCRIPTION
Sphinx 4 added logo_url and Sphinx 6 removed logo.
Furo dropped support for Sphinx 4, 5 and 6, so it's safe (and necessary) to change.